### PR TITLE
Restrict Gutenberg editor blocks

### DIFF
--- a/themes/blankslate-child/functions.php
+++ b/themes/blankslate-child/functions.php
@@ -7,3 +7,22 @@
  * @package Disability_Justice_Project
  */
 
+// Restrict blocks available to site authors
+function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
+  if ( $post->post_type !== 'post' ) {
+    return $allowed_block_types;
+  }
+  return array(
+    'core/paragraph',
+    'core/heading',
+    'core/list',
+    'core/quote',
+    'core/image',
+    'core/audio',
+    'core/video',
+    'core/image',
+    'core/shortcode'
+  );
+}
+add_filter( 'allowed_block_types', 'my_plugin_allowed_block_types', 10, 2 );
+?>


### PR DESCRIPTION
This PR limits the editor to a curated selection of blocks.