### PR TITLE
Use dynamic videos

### DIFF
--- a/themes/blankslate-child/sass/style.scss
+++ b/themes/blankslate-child/sass/style.scss
@@ -48,6 +48,7 @@ Text Domain: blankslate-child
 @import "utilities/alignments";
 @import "utilities/color-text";
 @import "utilities/embeds";
+@import "utilities/flow";
 @import "utilities/max-width";
 @import "utilities/text-and-background-color";
 @import "utilities/weights";

--- a/themes/blankslate-child/sass/utilities/_flow.scss
+++ b/themes/blankslate-child/sass/utilities/_flow.scss
@@ -1,0 +1,3 @@
+.u-flow > * + * {
+  margin-top: var(--size-250);
+}

--- a/themes/blankslate-child/tease-project.php
+++ b/themes/blankslate-child/tease-project.php
@@ -1,13 +1,18 @@
+<?php
+  $video_id = get_field('video_id');
+  $transcript = get_field('transcript');
+?>
+
 <div class="c-tease-project">
   <div class="c-tease-project__video">
     <div class="u-embed-responsive">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/SDdsD5AmKYA" title="YouTube: <?php the_title(); ?>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/<?php echo $video_id; ?>" title="YouTube: <?php the_title(); ?>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
   </div>
   <div class="c-tease-project__content">
     <h2 class="c-tease-project__title">
       <a class="c-tease-project__link" href="<?php the_permalink(); ?>">
-        <?php echo $video_id; ?><?php the_title(); ?>
+        <?php the_title(); ?>
       </a>
     </h2>
     <p class="c-tease-project__excerpt">


### PR DESCRIPTION
This PR uses custom field data to show a video dynamically alongside a video tease. The video's `id` is inserted dynamically into embed code. 

For example, this YouTube video: `https://youtu.be/a1ThSi1wbqU`. The `id` is the string `a1ThSi1wbqU` in the URL. Adding it to the custom field in a post with a category of Field will inject it into an embed template, allowing the video to be displayed. This sets up future scaffolding work for using whatever video hosting solution we wind up utilizing.