### PR TITLE
Show film transcripts

### DIFF
--- a/themes/blankslate-child/footer.php
+++ b/themes/blankslate-child/footer.php
@@ -19,6 +19,7 @@
   <?php endif; ?>
 
 </footer>
-<?php wp_footer(); ?>
+  <?php wp_footer(); ?>
+  <script src="/wp-content/themes/blankslate-child/js/main.js"></script>
 </body>
 </html>

--- a/themes/blankslate-child/images/icon-close.svg
+++ b/themes/blankslate-child/images/icon-close.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>icon-close</title>
+    <g id="icon-close" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <line x1="1.5" y1="1.5" x2="38.5" y2="38.5" id="Line" stroke="#000000" stroke-width="2"></line>
+        <line x1="1.5" y1="38.5" x2="38.5" y2="1.5" id="Line-Copy" stroke="#000000" stroke-width="2"></line>
+    </g>
+</svg>

--- a/themes/blankslate-child/js/main.js
+++ b/themes/blankslate-child/js/main.js
@@ -1,0 +1,26 @@
+(function($) {
+
+  // Toggle transcripts
+  var transcriptButtons = $('[data-transcript="button"]');
+  var transcriptContent = $('[data-transcript="content"]').hide();
+
+  transcriptButtons.click(function(event) {
+    var transcriptButton = $(event.target);
+    var transcriptContent = transcriptButton.parents(".c-tease-project").find('[data-transcript="content"]');
+
+    if ( transcriptButton.attr('aria-pressed') == 'false' ) {
+      transcriptButton.attr("aria-pressed", "true");
+      transcriptContent.attr("aria-hidden", "false");
+      transcriptContent.show().focus();
+      transcriptContent.get(0).scrollIntoView({behavior: "smooth"});
+    } else {
+      transcriptButton.attr("aria-pressed", "false");
+      transcriptContent.attr("aria-hidden", "true");
+      transcriptContent.hide();
+      transcriptButton.focus();
+    }
+    return false;
+  });
+
+
+})(jQuery);

--- a/themes/blankslate-child/sass/components/_tease-news.scss
+++ b/themes/blankslate-child/sass/components/_tease-news.scss
@@ -14,6 +14,7 @@
   }
 }
 
+
 .c-tease-news__title {
   margin-top: var(--size-300);
   max-width: 48ch;

--- a/themes/blankslate-child/sass/components/_tease-project.scss
+++ b/themes/blankslate-child/sass/components/_tease-project.scss
@@ -1,17 +1,20 @@
 .c-tease-project {
   border-bottom: var(--border-thin) solid var(--color-gray-light);
   display: grid;
-  gap: 2rem;
   margin-top: 3rem;
-  padding-bottom: 3rem;
+  margin-bottom: 3rem;
 
   @media (min-width: $breakpoint-medium) {
-    gap: 3rem;
-    grid-template-columns: 1.75fr 1fr;
-    padding-right: 6rem;
+    grid-template-columns: 1.5fr 1fr;
   }
 }
 
+
+.c-tease-project__video {
+  @media (min-width: $breakpoint-medium) {
+    margin-bottom: 1rem;
+  }
+}
 
 .c-tease-project__content {
   margin-left: 1.5rem;
@@ -19,8 +22,11 @@
 
   @media (min-width: $breakpoint-medium) {
     align-self: end;
-    margin-left: 0;
     margin-right: 0;
+    margin-bottom: 1rem;
+    margin-left: 0;
+    padding-right: 6rem;
+    padding-left: var(--font-size-600);
   }
 }
 
@@ -64,4 +70,42 @@
   font-weight: var(--type-weight-bold);
   flex-grow: 1;
   margin-right: 1rem;
+
+  // &::after {
+  //   background-color: var(--color-gray-light);
+  //   outline: var(--border-thin) solid var(--color-gray-light);
+  //   content: '';
+  //   display: block;
+  //   height: 1px;
+  //   border-bottom: 50px solid red;
+  //   position: relative;
+  //     top: 4rem;
+  //   width: 100%;
+  //   z-index: 1;
+  //   pointer-events: none;
+  // }
+
+  &[aria-pressed="true"] {
+    background: var(--color-gray-lightest) url('/wp-content/themes/blankslate-child/images/icon-close.svg') no-repeat center left -25%;
+    background-size: 50% 50%;
+    border-color: var(--color-gray-lightest);
+    color: var(--color-black);
+  }
+}
+
+
+.c-tease-project__accordion-wrapper {
+  background-color: var(--color-gray-lightest);
+  color: var(--color-black);
+  font-family: var(--font-tertiary);
+  grid-column-start: 1;
+  grid-column-end: 3;
+  margin-bottom: 3rem;
+}
+
+
+.c-tease-project__accordion-content {
+  max-width: 74ch;
+  margin: 0 auto;
+  padding: var(--size-800) var(--size-200);
 }

--- a/themes/blankslate-child/sass/layouts/_tease-news.scss
+++ b/themes/blankslate-child/sass/layouts/_tease-news.scss
@@ -10,7 +10,7 @@
     grid-template-areas:
       '. title .'
       '. news  .';
-      padding: 4rem 0 5rem 0;
+    padding: var(--size-800) 0 5rem 0;
   }
 }
 

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -1087,6 +1087,10 @@ table tfoot tr td {
 	width: 100%;
 }
 
+.u-flow > * + * {
+	margin-top: var(--size-250);
+}
+
 .u-max-width-content {
 	max-width: 74rem;
 }
@@ -1272,7 +1276,7 @@ table tfoot tr td {
 		grid-template-columns: 0.1fr 1fr 0.1fr;
 		grid-template-rows: auto;
 		grid-template-areas: '. title .' '. news  .';
-		padding: 4rem 0 5rem 0;
+		padding: var(--size-800) 0 5rem 0;
 	}
 }
 
@@ -1762,16 +1766,19 @@ table tfoot tr td {
 .c-tease-project {
 	border-bottom: var(--border-thin) solid var(--color-gray-light);
 	display: grid;
-	gap: 2rem;
 	margin-top: 3rem;
-	padding-bottom: 3rem;
+	margin-bottom: 3rem;
 }
 
 @media (min-width: 70rem) {
 	.c-tease-project {
-		gap: 3rem;
-		grid-template-columns: 1.75fr 1fr;
-		padding-right: 6rem;
+		grid-template-columns: 1.5fr 1fr;
+	}
+}
+
+@media (min-width: 70rem) {
+	.c-tease-project__video {
+		margin-bottom: 1rem;
 	}
 }
 
@@ -1783,8 +1790,11 @@ table tfoot tr td {
 @media (min-width: 70rem) {
 	.c-tease-project__content {
 		align-self: end;
-		margin-left: 0;
 		margin-right: 0;
+		margin-bottom: 1rem;
+		margin-left: 0;
+		padding-right: 6rem;
+		padding-left: var(--font-size-600);
 	}
 }
 
@@ -1823,6 +1833,28 @@ table tfoot tr td {
 	font-weight: var(--type-weight-bold);
 	flex-grow: 1;
 	margin-right: 1rem;
+}
+
+.c-tease-project__transcript[aria-pressed="true"] {
+	background: var(--color-gray-lightest) url("/wp-content/themes/blankslate-child/images/icon-close.svg") no-repeat center left -25%;
+	background-size: 50% 50%;
+	border-color: var(--color-gray-lightest);
+	color: var(--color-black);
+}
+
+.c-tease-project__accordion-wrapper {
+	background-color: var(--color-gray-lightest);
+	color: var(--color-black);
+	font-family: var(--font-tertiary);
+	grid-column-start: 1;
+	grid-column-end: 3;
+	margin-bottom: 3rem;
+}
+
+.c-tease-project__accordion-content {
+	max-width: 74ch;
+	margin: 0 auto;
+	padding: var(--size-800) var(--size-200);
 }
 
 .c-update-banner {

--- a/themes/blankslate-child/tease-project.php
+++ b/themes/blankslate-child/tease-project.php
@@ -33,8 +33,12 @@
       </div>
     </div>
     <div class="c-tease-project__tools">
-      <button type="button" class="c-tease-project__transcript">
-        Transcript
+      <button
+        data-transcript="button"
+        aria-pressed="false"
+        type="button"
+        class="c-tease-project__transcript">
+        Transcript<span class="screen-reader-text"> for <?php the_title(); ?></span>
       </button>
       <button type="button" class="c-share__facebook">
         <svg class="c-share__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M279.14 288l14.22-92.66h-88.91v-60.13c0-25.35 12.42-50.06 52.24-50.06h40.42V6.26S260.43 0 225.36 0c-73.22 0-121.08 44.38-121.08 124.72v70.62H22.89V288h81.39v224h100.17V288z"></path></svg>

--- a/themes/blankslate-child/tease-project.php
+++ b/themes/blankslate-child/tease-project.php
@@ -50,4 +50,14 @@
       </button>
     </div>
   </div>
+  <div class="c-tease-project__accordion-wrapper">
+    <section
+      aria-hidden="true"
+      aria-label="Transcript for <?php the_title(); ?>"
+      class="c-tease-project__accordion-content u-flow"
+      data-transcript="content"
+      tabindex="-1">
+      <?php echo $transcript; ?>
+    </section>
+  </div>
 </div>


### PR DESCRIPTION
This PR shows film transcripts when the user clicks the "Transcript" button, then hides the transcript when clicked again.

https://user-images.githubusercontent.com/634191/123129569-0bf86b00-d41a-11eb-85fa-f7ad57b7e90d.mp4

@danzedek Particulars to discuss this afternoon:

- I still need to add the "lip" that connects the transcript button to the transcript content area. It's proving to be a little tricky, but I wanted to show that functionality is there.
- I am using an animated transition to scroll the user to the transcripts, to help communicate they're linked to the video, as the transcript area is a full-width content section. I have some reservations about this animation effect with regards to vestibular triggers.
- I am treating the transcript content area as accordion from a screen reader perspective, but could see the argument that it's a [non-modal dialog](https://accessuse.eu/en/non-modal-dialogs.html). If we test with SR users, I'm curious to see how it'll be received.
    - In particular, is the toggled state of the transcript button, plus moving focus to the transcript content sufficient? The content area also has a landmark role, which should help communicate.

