### PR TITLE
Fix video breakpoint

### DIFF
--- a/themes/blankslate-child/sass/components/_creator.scss
+++ b/themes/blankslate-child/sass/components/_creator.scss
@@ -23,7 +23,7 @@
 }
 
 
-.c-creator__excerpt {
+.c-creator__bio {
   font-size: var(--font-size-150);
   margin-left: var(--size-200);
   max-width: 65ch;

--- a/themes/blankslate-child/sass/components/_tease-project.scss
+++ b/themes/blankslate-child/sass/components/_tease-project.scss
@@ -1,10 +1,10 @@
 .c-tease-project {
   border-bottom: var(--border-thin) solid var(--color-gray-light);
-  display: grid;
-  margin-top: 3rem;
-  margin-bottom: 3rem;
+  margin-top: var(--size-600);
+  margin-bottom: var(--size-600);
 
   @media (min-width: $breakpoint-medium) {
+    display: grid;
     grid-template-columns: 1.5fr 1fr;
   }
 }
@@ -12,19 +12,18 @@
 
 .c-tease-project__video {
   @media (min-width: $breakpoint-medium) {
-    margin-bottom: 1rem;
+    margin-bottom: var(--size-200);
   }
 }
 
 .c-tease-project__content {
-  margin-left: 1.5rem;
-  margin-right: 1.5rem;
+  margin-top: var(--size-400);
+  margin-right: var(--size-300);
+  margin-left: var(--size-300);
 
   @media (min-width: $breakpoint-medium) {
     align-self: end;
-    margin-right: 0;
-    margin-bottom: 1rem;
-    margin-left: 0;
+    margin: 0 0 var(--size-200) 0;
     padding-right: 6rem;
     padding-left: var(--font-size-600);
   }
@@ -32,7 +31,7 @@
 
 
 .c-tease-project__title {
-  font-size: 2rem;
+  font-size: var(--font-size-400);
   line-height: var(--line-height-200);
   max-width: 65ch;
 }
@@ -54,22 +53,22 @@
 
 
 .c-tease-project__excerpt {
-  margin-top: 0.5rem;
+  margin-top: var(--size-100);
   max-width: 65ch;
 }
 
 
 .c-tease-project__tools {
   display: flex;
-  gap: 1rem;
-  margin-top: 2rem;
+  gap: var(--size-200);
+  margin-top: var(--size-400);
 }
 
 
 .c-tease-project__transcript {
   font-weight: var(--type-weight-bold);
   flex-grow: 1;
-  margin-right: 1rem;
+  margin-right: var(--size-200);
 
   // &::after {
   //   background-color: var(--color-gray-light);
@@ -100,7 +99,7 @@
   font-family: var(--font-tertiary);
   grid-column-start: 1;
   grid-column-end: 3;
-  margin-bottom: 3rem;
+  margin-bottom: var(--size-600);
 }
 
 

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -12,7 +12,6 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: light, responsive-layout, accessibility-ready
 Text Domain: blankslate-child
 */
-
 /* Hide the Posts Navigation and the Footer when Infinite Scroll is in use. */
 .infinite-scroll .posts-navigation,
 .infinite-scroll.neverending .site-footer {
@@ -25,10 +24,8 @@ Text Domain: blankslate-child
 }
 
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
-
 /* Document
 	 ========================================================================== */
-
 /**
  * 1. Correct the line height in all browsers.
  * 2. Prevent adjustments of font size after orientation changes in iOS.
@@ -40,7 +37,6 @@ html {
 
 /* Sections
 	 ========================================================================== */
-
 /**
  * Remove the margin in all browsers.
  */
@@ -66,7 +62,6 @@ h1 {
 
 /* Grouping content
 	 ========================================================================== */
-
 /**
  * 1. Add the correct box sizing in Firefox.
  * 2. Show the overflow in Edge and IE.
@@ -88,7 +83,6 @@ pre {
 
 /* Text-level semantics
 	 ========================================================================== */
-
 /**
  * Remove the gray background on active links in IE 10.
  */
@@ -154,7 +148,6 @@ sup {
 
 /* Embedded content
 	 ========================================================================== */
-
 /**
  * Remove the border on images inside links in IE 10.
  */
@@ -164,7 +157,6 @@ img {
 
 /* Forms
 	 ========================================================================== */
-
 /**
  * 1. Change the font styles in all browsers.
  * 2. Remove the margin in Firefox and Safari.
@@ -310,7 +302,6 @@ textarea {
 
 /* Interactive
 	 ========================================================================== */
-
 /*
  * Add the correct display in Edge, IE 10+, and Firefox.
  */
@@ -327,7 +318,6 @@ summary {
 
 /* Misc
 	 ========================================================================== */
-
 /**
  * Add the correct display in IE 10+.
  */
@@ -359,39 +349,39 @@ figure {
 }
 
 @font-face {
-	font-family: "Halyard Text";
+	font-family: 'Halyard Text';
 	src: url(/wp-content/themes/blankslate-child/fonts/HalyardTextMed.woff2) format("woff2"), url(/wp-content/themes/blankslate-child/fonts/HalyardTextMed.woff) format("woff");
 	font-weight: 400;
 }
 
 @font-face {
-	font-family: "Halyard Text";
+	font-family: 'Halyard Text';
 	src: url(/wp-content/themes/blankslate-child/fonts/HalyardTextMed-It.woff2) format("woff2"), url(/wp-content/themes/blankslate-child/fonts/HalyardTextMed-It.woff) format("woff");
 	font-weight: 400;
 	font-style: italic;
 }
 
 @font-face {
-	font-family: "Halyard Display";
+	font-family: 'Halyard Display';
 	src: url(/wp-content/themes/blankslate-child/fonts/HalyardDisMed.woff2) format("woff2"), url(/wp-content/themes/blankslate-child/fonts/HalyardDisMed.woff) format("woff");
 	font-weight: 500;
 }
 
 @font-face {
-	font-family: "Halyard Display";
+	font-family: 'Halyard Display';
 	src: url(/wp-content/themes/blankslate-child/fonts/HalyardDisMed-It.woff2) format("woff2"), url(/wp-content/themes/blankslate-child/fonts/HalyardDisMed-It.woff) format("woff");
 	font-weight: 500;
 	font-style: italic;
 }
 
 @font-face {
-	font-family: "Halyard Display";
+	font-family: 'Halyard Display';
 	src: url(/wp-content/themes/blankslate-child/fonts/HalyardDis-Bd.woff2) format("woff2"), url(/wp-content/themes/blankslate-child/fonts/HalyardDis-Bd.woff) format("woff");
 	font-weight: 700;
 }
 
 @font-face {
-	font-family: "Halyard Display";
+	font-family: 'Halyard Display';
 	src: url(/wp-content/themes/blankslate-child/fonts/HalyardDis-BdIt-It.woff2) format("woff2"), url(/wp-content/themes/blankslate-child/fonts/HalyardDis-BdIt-It.woff) format("woff");
 	font-weight: 700;
 	font-style: italic;
@@ -409,8 +399,8 @@ figure {
 :root {
 	--border-thin: 1px;
 	--border-thick: 3px;
-	--color-white: #fff;
-	--color-black: #000;
+	--color-white: #ffffff;
+	--color-black: #000000;
 	--color-gray-lightest: #ebe8e7;
 	--color-gray-light: #e0d7d7;
 	--color-gray-medium: #bdb4b4;
@@ -420,9 +410,9 @@ figure {
 	--color-brick: #da4c27;
 	--color-olive: #76c43b;
 	--color-dusk: #00a6d3;
-	--font-primary: "Halyard Display", arial, sans-serif;
-	--font-secondary: "Halyard Text", arial, sans-serif;
-	--font-tertiary: timesnewroman, "Times New Roman", times, georgia, serif;
+	--font-primary: 'Halyard Display', Arial, sans-serif;
+	--font-secondary: 'Halyard Text', Arial, sans-serif;
+	--font-tertiary: TimesNewRoman, 'Times New Roman', Times, Georgia, serif;
 	--font-size-100: 0.8rem;
 	--font-size-150: 0.9rem;
 	--font-size-200: 1rem;
@@ -498,21 +488,18 @@ html:lang(en-US) {
 }
 
 @supports (hanging-punctuation: first) {
-
 	html {
 		hanging-punctuation: first;
 	}
 }
 
 @media screen and (-webkit-min-device-pixel-ratio: 2), screen and (min-resolution: 2dppx) {
-
 	html {
 		font-smoothing: subpixel-antialiased;
 	}
 }
 
 @-ms-viewport {
-
 	html {
 		width: device-width;
 	}
@@ -605,8 +592,7 @@ picture {
 	vertical-align: middle;
 }
 
-img[height],
-img[width],
+img[height], img[width],
 figure[height],
 figure[width],
 picture[height],
@@ -662,22 +648,17 @@ sub {
 }
 
 @supports not (font-variant-position: sub) {
-
 	sub {
 		/* stylelint-disable-next-line property-no-vendor-prefix */
 		-webkit-font-feature-settings: "subs", "subs";
 		font-feature-settings: "subs", "subs";
 	}
-
 	@supports (-webkit-font-feature-settings: "subs") or (font-feature-settings: "subs") {
-
 		sub {
 			vertical-align: baseline;
 		}
 	}
-
 	@supports (overflow: -webkit-marquee) and (justify-content: inherit) {
-
 		sub {
 			vertical-align: sub;
 			font-size: smaller;
@@ -691,22 +672,17 @@ sup {
 }
 
 @supports not (font-variant-position: sup) {
-
 	sup {
 		/* stylelint-disable-next-line property-no-vendor-prefix */
 		-webkit-font-feature-settings: "sups", "sups";
 		font-feature-settings: "sups", "sups";
 	}
-
 	@supports (-webkit-font-feature-settings: "sups") or (font-feature-settings: "sups") {
-
 		sup {
 			vertical-align: baseline;
 		}
 	}
-
 	@supports (overflow: -webkit-marquee) and (justify-content: inherit) {
-
 		sup {
 			vertical-align: super;
 		}
@@ -779,7 +755,6 @@ time {
 }
 
 @supports not (font-variant-numeric: tabular-nums) {
-
 	time {
 		/* stylelint-disable-next-line property-no-vendor-prefix */
 		-webkit-font-feature-settings: "pnum" 0, "tnum", "tnum";
@@ -788,7 +763,6 @@ time {
 }
 
 @supports not (font-variant-numeric: oldstyle-nums) {
-
 	time {
 		/* stylelint-disable-next-line property-no-vendor-prefix */
 		-webkit-font-feature-settings: "lnum" 0, "onum", "onum";
@@ -797,7 +771,6 @@ time {
 }
 
 @supports not ((-webkit-font-feature-settings: "onum" inherit) or (font-feature-settings: "onum" inherit)) {
-
 	time {
 		/* stylelint-disable-next-line property-no-vendor-prefix */
 		-webkit-font-feature-settings: "lnum" 0, "onum", "pnum" 0, "tnum";
@@ -806,7 +779,6 @@ time {
 }
 
 @supports not ((-webkit-font-feature-settings: "onum" inherit) or (font-feature-settings: "onum" inherit)) {
-
 	time {
 		/* stylelint-disable-next-line property-no-vendor-prefix */
 		-webkit-font-feature-settings: "lnum" 0, "onum", "pnum" 0, "tnum";
@@ -831,18 +803,14 @@ input[type="submit"] {
 	line-height: var(--line-height-100);
 }
 
-.u-dark-on-light button,
-.u-dark-on-light
-input[type="button"],
-.u-dark-on-light
-input[type="reset"],
-.u-dark-on-light
+.u-dark-on-light button, .u-dark-on-light
+input[type="button"], .u-dark-on-light
+input[type="reset"], .u-dark-on-light
 input[type="submit"] {
 	border-color: var(--color-black);
 }
 
-button:hover,
-button:focus,
+button:hover, button:focus,
 input[type="button"]:hover,
 input[type="button"]:focus,
 input[type="reset"]:hover,
@@ -854,19 +822,12 @@ input[type="submit"]:focus {
 	color: var(--color-black);
 }
 
-.u-dark-on-light button:hover,
-.u-dark-on-light button:focus,
-.u-dark-on-light
-input[type="button"]:hover,
-.u-dark-on-light
-input[type="button"]:focus,
-.u-dark-on-light
-input[type="reset"]:hover,
-.u-dark-on-light
-input[type="reset"]:focus,
-.u-dark-on-light
-input[type="submit"]:hover,
-.u-dark-on-light
+.u-dark-on-light button:hover, .u-dark-on-light button:focus, .u-dark-on-light
+input[type="button"]:hover, .u-dark-on-light
+input[type="button"]:focus, .u-dark-on-light
+input[type="reset"]:hover, .u-dark-on-light
+input[type="reset"]:focus, .u-dark-on-light
+input[type="submit"]:hover, .u-dark-on-light
 input[type="submit"]:focus {
 	border-color: var(--color-black);
 }
@@ -961,9 +922,7 @@ a {
 	color: #4169e1;
 }
 
-a:hover,
-a:focus,
-a:active {
+a:hover, a:focus, a:active {
 	color: #191970;
 }
 
@@ -1046,20 +1005,16 @@ table tfoot tr td {
 }
 
 .alignleft {
-
 	/*rtl:ignore*/
 	float: left;
-
 	/*rtl:ignore*/
 	margin-right: 1.5em;
 	margin-bottom: 1.5em;
 }
 
 .alignright {
-
 	/*rtl:ignore*/
 	float: right;
-
 	/*rtl:ignore*/
 	margin-left: 1.5em;
 	margin-bottom: 1.5em;
@@ -1185,7 +1140,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-footer {
 		align-items: flex-end;
 		flex-direction: row;
@@ -1206,7 +1160,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-header {
 		align-items: flex-end;
 		flex-direction: row;
@@ -1231,7 +1184,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-landing {
 		grid-template-columns: 10rem 2rem 2fr;
 		padding-left: 0;
@@ -1248,7 +1200,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-landing__title {
 		display: grid;
 		grid-template-columns: 10rem 2rem 2fr;
@@ -1264,7 +1215,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-landing__topic {
 		grid-column-start: 1;
 		grid-column-end: 2;
@@ -1276,7 +1226,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-landing__heading {
 		grid-column-start: 3;
 		grid-column-end: 6;
@@ -1293,7 +1242,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-landing__share {
 		grid-column-start: 1;
 		grid-column-end: 3;
@@ -1303,7 +1251,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-landing__content {
 		grid-column-start: 3;
 		grid-column-end: 6;
@@ -1311,7 +1258,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-landing__person {
 		grid-column-start: 1;
 		grid-column-end: 6;
@@ -1325,12 +1271,11 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-tease-news {
 		display: grid;
 		grid-template-columns: 0.1fr 1fr 0.1fr;
 		grid-template-rows: auto;
-		grid-template-areas: ". title ." ". news  .";
+		grid-template-areas: '. title .' '. news  .';
 		padding: var(--size-800) 0 5rem 0;
 	}
 }
@@ -1350,7 +1295,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.l-tease-news__posts {
 		grid-template-columns: 1fr 1fr 1fr;
 	}
@@ -1363,20 +1307,16 @@ table tfoot tr td {
 }
 
 @media screen and (min-width: 37.5em) {
-
 	.menu-toggle {
 		display: none;
 	}
-
 	.main-navigation ul {
 		display: flex;
 	}
 }
 
-.site-main .comment-navigation,
-.site-main
-.posts-navigation,
-.site-main
+.site-main .comment-navigation, .site-main
+.posts-navigation, .site-main
 .post-navigation {
 	margin: 0 0 1.5em;
 }
@@ -1580,7 +1520,7 @@ table tfoot tr td {
 	width: var(--size-900);
 }
 
-.c-creator__excerpt {
+.c-creator__bio {
 	font-size: var(--font-size-150);
 	margin-left: var(--size-200);
 	max-width: 65ch;
@@ -1592,8 +1532,7 @@ table tfoot tr td {
 	text-transform: uppercase;
 }
 
-.c-creator__read-more:hover,
-.c-creator__read-more:focus {
+.c-creator__read-more:hover, .c-creator__read-more:focus {
 	color: var(--color-gold);
 	text-decoration: none;
 }
@@ -1639,7 +1578,6 @@ table tfoot tr td {
 }
 
 @media (min-width: 70rem) {
-
 	.c-footer__tagline {
 		padding: 0;
 	}
@@ -1667,13 +1605,11 @@ table tfoot tr td {
 	padding-top: var(--size-150);
 }
 
-.c-nav-primary li a:hover,
-.c-nav-primary li a:focus {
+.c-nav-primary li a:hover, .c-nav-primary li a:focus {
 	border-bottom-color: transparent;
 }
 
 @media (min-width: 70rem) {
-
 	.c-nav-primary li a {
 		min-width: 12ch;
 	}
@@ -1683,8 +1619,7 @@ table tfoot tr td {
 	border-bottom-color: var(--color-gold);
 }
 
-.c-nav-primary li:nth-of-type(1) a:hover,
-.c-nav-primary li:nth-of-type(1) a:focus {
+.c-nav-primary li:nth-of-type(1) a:hover, .c-nav-primary li:nth-of-type(1) a:focus {
 	border-bottom-color: transparent;
 }
 
@@ -1692,8 +1627,7 @@ table tfoot tr td {
 	border-bottom-color: var(--color-brick);
 }
 
-.c-nav-primary li:nth-of-type(2) a:hover,
-.c-nav-primary li:nth-of-type(2) a:focus {
+.c-nav-primary li:nth-of-type(2) a:hover, .c-nav-primary li:nth-of-type(2) a:focus {
 	border-bottom-color: transparent;
 }
 
@@ -1701,8 +1635,7 @@ table tfoot tr td {
 	border-bottom-color: var(--color-dusk);
 }
 
-.c-nav-primary li:nth-of-type(3) a:hover,
-.c-nav-primary li:nth-of-type(3) a:focus {
+.c-nav-primary li:nth-of-type(3) a:hover, .c-nav-primary li:nth-of-type(3) a:focus {
 	border-bottom-color: transparent;
 }
 
@@ -1710,8 +1643,7 @@ table tfoot tr td {
 	border-bottom-color: var(--color-olive);
 }
 
-.c-nav-primary li:nth-of-type(4) a:hover,
-.c-nav-primary li:nth-of-type(4) a:focus {
+.c-nav-primary li:nth-of-type(4) a:hover, .c-nav-primary li:nth-of-type(4) a:focus {
 	border-bottom-color: transparent;
 }
 
@@ -1719,15 +1651,14 @@ table tfoot tr td {
 	display: grid;
 	gap: 2rem;
 	grid-template-columns: 1fr;
-	grid-template-areas: "photo" "content";
+	grid-template-areas: 'photo' 'content';
 	margin-top: var(--size-300);
 }
 
 @media (min-width: 70rem) {
-
 	.c-mentor {
 		grid-template-columns: 10rem 1fr;
-		grid-template-areas: "photo content";
+		grid-template-areas: 'photo content';
 		margin-top: var(--size-600);
 	}
 }
@@ -1765,8 +1696,7 @@ table tfoot tr td {
 	width: 3rem;
 }
 
-.c-share__facebook:hover .c-share__icon,
-.c-share__facebook:focus .c-share__icon,
+.c-share__facebook:hover .c-share__icon, .c-share__facebook:focus .c-share__icon,
 .c-share__twitter:hover .c-share__icon,
 .c-share__twitter:focus .c-share__icon,
 .c-share__email:hover .c-share__icon,
@@ -1822,8 +1752,7 @@ table tfoot tr td {
 	text-decoration: none;
 }
 
-.c-tease-news__link:hover,
-.c-tease-news__link:focus {
+.c-tease-news__link:hover, .c-tease-news__link:focus {
 	color: var(--color-brick);
 	text-decoration: underline;
 }
@@ -1836,44 +1765,40 @@ table tfoot tr td {
 
 .c-tease-project {
 	border-bottom: var(--border-thin) solid var(--color-gray-light);
-	display: grid;
-	margin-top: 3rem;
-	margin-bottom: 3rem;
+	margin-top: var(--size-600);
+	margin-bottom: var(--size-600);
 }
 
 @media (min-width: 70rem) {
-
 	.c-tease-project {
+		display: grid;
 		grid-template-columns: 1.5fr 1fr;
 	}
 }
 
 @media (min-width: 70rem) {
-
 	.c-tease-project__video {
-		margin-bottom: 1rem;
+		margin-bottom: var(--size-200);
 	}
 }
 
 .c-tease-project__content {
-	margin-left: 1.5rem;
-	margin-right: 1.5rem;
+	margin-top: var(--size-400);
+	margin-right: var(--size-300);
+	margin-left: var(--size-300);
 }
 
 @media (min-width: 70rem) {
-
 	.c-tease-project__content {
 		align-self: end;
-		margin-right: 0;
-		margin-bottom: 1rem;
-		margin-left: 0;
+		margin: 0 0 var(--size-200) 0;
 		padding-right: 6rem;
 		padding-left: var(--font-size-600);
 	}
 }
 
 .c-tease-project__title {
-	font-size: 2rem;
+	font-size: var(--font-size-400);
 	line-height: var(--line-height-200);
 	max-width: 65ch;
 }
@@ -1883,8 +1808,7 @@ table tfoot tr td {
 	text-decoration: none;
 }
 
-.c-tease-project__link:hover,
-.c-tease-project__link:focus {
+.c-tease-project__link:hover, .c-tease-project__link:focus {
 	color: var(--color-gold);
 	text-decoration: underline;
 }
@@ -1894,20 +1818,20 @@ table tfoot tr td {
 }
 
 .c-tease-project__excerpt {
-	margin-top: 0.5rem;
+	margin-top: var(--size-100);
 	max-width: 65ch;
 }
 
 .c-tease-project__tools {
 	display: flex;
-	gap: 1rem;
-	margin-top: 2rem;
+	gap: var(--size-200);
+	margin-top: var(--size-400);
 }
 
 .c-tease-project__transcript {
 	font-weight: var(--type-weight-bold);
 	flex-grow: 1;
-	margin-right: 1rem;
+	margin-right: var(--size-200);
 }
 
 .c-tease-project__transcript[aria-pressed="true"] {
@@ -1923,7 +1847,7 @@ table tfoot tr td {
 	font-family: var(--font-tertiary);
 	grid-column-start: 1;
 	grid-column-end: 3;
-	margin-bottom: 3rem;
+	margin-bottom: var(--size-600);
 }
 
 .c-tease-project__accordion-content {
@@ -1942,3 +1866,5 @@ table tfoot tr td {
 	margin-top: var(--size-500);
 	margin-bottom: var(--size-400);
 }
+
+/*# sourceMappingURL=style.css.map */

--- a/themes/blankslate-child/tease-project.php
+++ b/themes/blankslate-child/tease-project.php
@@ -32,7 +32,7 @@
             class="c-creator__photo"
             src="<?php echo $temp_filmmaker_photo['url']; ?>">
         <?php endif; ?>
-        <div class="c-creator__excerpt">
+        <div class="c-creator__bio">
           <?php echo $temp_filmmaker_bio; ?>
         </div>
       </div>

--- a/themes/blankslate-child/update-banner.php
+++ b/themes/blankslate-child/update-banner.php
@@ -1,7 +1,7 @@
 <?php if ( ! empty($new_video)) : ?>
   <div class="c-update-banner">
     <p id="title" class="c-update-banner__message">
-      New videos <span class="u-color-text-gray-brick"><?php echo $new_video; ?></span>
+      New videos<span class="screen-reader-text">:</span> <span class="u-color-text-gray-brick"><?php echo $new_video; ?><span class="screen-reader-text">.</span></span>
     </p>
   </div>
 <?php endif; ?>


### PR DESCRIPTION
This PR restores the presence of videos on smaller breakpoints. Previously they were being moved offscreen by a mis-scoped `display: grid;` declaration.