### PR TITLE
Update modal for user testing

### DIFF
--- a/themes/blankslate-child/accessibility-settings-modal.php
+++ b/themes/blankslate-child/accessibility-settings-modal.php
@@ -1,7 +1,4 @@
-<div
-  id="accessibility-settings-modal"
-  data-modal
-  hidden>
+<div hidden id="accessibility-settings-modal">
   <div
     class="c-accessibility-modal"
     data-modal-document>

--- a/themes/blankslate-child/footer.php
+++ b/themes/blankslate-child/footer.php
@@ -17,7 +17,5 @@
 </footer>
   <?php wp_footer(); ?>
   <script src="/wp-content/themes/blankslate-child/js/main.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/inert-polyfill@0.2.5/inert-polyfill.min.js" integrity="sha256-Eyd34WbRWISxSokarNMU5jEfiZNTno6r8zrbV/CFHrE=" crossorigin="anonymous"></script>
-  <script src="/wp-content/themes/blankslate-child/js/aria.modal.min.js"></script>
 </body>
 </html>

--- a/themes/blankslate-child/header.php
+++ b/themes/blankslate-child/header.php
@@ -37,8 +37,6 @@
 
 <body <?php body_class(); ?>>
 
-<?php get_template_part('accessibility-settings-modal');?>
-
 <?php wp_body_open(); ?>
 
 <a class="skip-link screen-reader-text" href="#primary"><?php esc_html_e( 'Skip to content', 'disabilityjusticeproject' ); ?></a>
@@ -64,10 +62,8 @@
 
   <div class="l-header__accessibility-settings">
     <button
-      id="accessibility-settings"
-      data-modal-open="accessibility-settings-modal"
+      id="accessibility-settings-toggle"
       class="c-accessibility-settings__toggle"
-      hidden
       type="button">
       <svg
         class="c-accessibility-settings__toggle-icon"
@@ -85,5 +81,7 @@
     <?php wp_nav_menu( array( 'theme_location' => 'main-menu' ) ); ?>
   </nav>
 </header>
+
+<?php get_template_part('accessibility-settings-modal');?>
 
 </div>

--- a/themes/blankslate-child/js/main.js
+++ b/themes/blankslate-child/js/main.js
@@ -1,5 +1,19 @@
 (function($) {
 
+  var accessibilitySettingsToggle = $('#accessibility-settings-toggle');
+  var accessibilitySettingsModal = $('#accessibility-settings-modal');
+
+  accessibilitySettingsToggle.click(function(event) {
+    if ( accessibilitySettingsModal.attr('hidden') ) {
+      accessibilitySettingsModal.removeAttr('hidden');
+      console.log("modal open");
+    } else {
+      accessibilitySettingsModal.prop('hidden', true);
+      console.log("modal closed");
+    }
+    return false;
+  });
+
   // Toggle transcripts
   var transcriptButtons = $('[data-transcript="button"]');
   var transcriptContent = $('[data-transcript="content"]').hide();
@@ -21,6 +35,5 @@
     }
     return false;
   });
-
 
 })(jQuery);


### PR DESCRIPTION
This PR quickly updates the modal for user testing. It:

- Removes the aria-modal library
- Moves the modal to below the primary navigation

*Notes:* 

- This modal treatment does not have non-modal dialog assistive technology mappings set up yet, and may not work for a screen reader user. Improvements to follow, but may not be ready by tomorrow.
- The Accessibility Settings button is the only toggle for closing the menu.
- The Accessibility Settings button currently does not have a visual toggled state, inline with the first bullet point of this list.

<img width="1486" alt="ScreenCapture at Mon Jun 28 19:59:17 EDT 2021" src="https://user-images.githubusercontent.com/634191/123717773-8d516280-d84b-11eb-867e-7d2db4e1390e.png">
