### PR TITLE
Use associated custom fields information

### DIFF
--- a/themes/blankslate-child/entry-content.php
+++ b/themes/blankslate-child/entry-content.php
@@ -1,8 +1,6 @@
 <?php
+  $associated_filmmaker = get_field('associated_filmmaker');
   $transcript = get_field('transcript');
-  $temp_filmmaker_name = get_field('temp_filmmaker_name');
-  $temp_filmmaker_photo = get_field('temp_filmmaker_photo');
-  $temp_filmmaker_bio = get_field('temp_filmmaker_bio');
 ?>
 
   <div class="l-landing__byline">
@@ -38,18 +36,16 @@
 
   </div>
 
-  <?php if ( ! empty($temp_filmmaker_photo)) : ?>
-    <img
-      alt="Photo of <?php echo $temp_filmmaker_name; ?>."
-      class="c-filmmaker__photo"
-      src="<?php echo $temp_filmmaker_photo['url']; ?>" />
-  <?php endif; ?>
+  <img
+    alt="Photo of <?php echo esc_html( $associated_filmmaker->post_title ); ?>."
+    class="c-filmmaker__photo"
+    src="<?php echo get_the_post_thumbnail($associated_filmmaker, 'large'); ?>
   <div class="c-filmmaker__content">
     <h3 class="c-filmmaker__name">
-      <?php echo $temp_filmmaker_name; ?>
+      <?php echo esc_html( $associated_filmmaker->post_title ); ?>
     </h3>
     <div class="c-filmmaker__bio">
-      <?php echo $temp_filmmaker_bio; ?>
+      <?php echo esc_html( $associated_filmmaker->post_excerpt ); ?>
     </div>
   </div>
 

--- a/themes/blankslate-child/filmmaker.php
+++ b/themes/blankslate-child/filmmaker.php
@@ -1,15 +1,6 @@
-<?php
-  $filmmaker_photo = get_field('filmmaker_photo');
-?>
-
-<?php if ( ! empty($filmmaker_photo)) : ?>
-  <img
-    alt="Photo of <?php the_title(); ?>."
-    class="c-filmmaker__photo"
-    src="<?php echo $filmmaker_photo['url']; ?>" />
-<?php endif; ?>
+<?php echo the_post_thumbnail('large', ['class' => 'c-filmmaker__photo']); ?>
 <div class="c-filmmaker__content">
-  <h3 class="c-filmmaker__name">
+  <h3 id="<?php echo sanitize_title(get_the_title()) ?>" class="c-filmmaker__name">
     <?php the_title(); ?>
   </h3>
   <div class="c-filmmaker__bio">

--- a/themes/blankslate-child/functions.php
+++ b/themes/blankslate-child/functions.php
@@ -27,4 +27,19 @@ function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
 }
 add_filter( 'allowed_block_types', 'my_plugin_allowed_block_types', 10, 2 );
 
+
+// Filter except length
+function excerpt($limit) {
+  $excerpt = explode(' ', get_the_excerpt(), $limit);
+  if (count($excerpt)>=$limit) {
+    array_pop($excerpt);
+    $excerpt = implode(" ",$excerpt).'';
+  } else {
+    $excerpt = implode(" ",$excerpt);
+  }
+  $excerpt = preg_replace('`[[^]]*]`','',$excerpt);
+  return $excerpt;
+}
+
+
 ?>

--- a/themes/blankslate-child/header.php
+++ b/themes/blankslate-child/header.php
@@ -48,15 +48,19 @@
     the_custom_logo();
     if ( is_front_page() && is_home() ) :
     ?>
-      <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-        <?php get_template_part('logo');?>
-      </a>
+      <div>
+        <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
+          <?php get_template_part('logo');?>
+        </a>
+      </div>
     <?php
     else :
     ?>
-      <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-        <?php get_template_part('logo');?>
-      </a>
+      <div>
+        <a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
+          <?php get_template_part('logo');?>
+        </a>
+      </div>
     <?php
   endif; ?>
 

--- a/themes/blankslate-child/sass/components/_content.scss
+++ b/themes/blankslate-child/sass/components/_content.scss
@@ -62,5 +62,6 @@
 
   p:first-of-type {
     font-size: var(--font-size-300);
+    margin-bottom: var(--size-350);
   }
 }

--- a/themes/blankslate-child/sass/components/_creator.scss
+++ b/themes/blankslate-child/sass/components/_creator.scss
@@ -3,7 +3,7 @@
 }
 
 
-.c-creator__bio {
+.c-creator__info {
   display: flex;
   margin-top: var(--size-050);
 }
@@ -32,6 +32,7 @@
 
 .c-creator__read-more {
   color: var(--color-gold);
+  display: inline;
   font-weight: var(--type-weight-bold);
   text-transform: uppercase;
 

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -1781,13 +1781,14 @@ img.u-effect-gold-screen:hover {
 
 .c-content--project p:first-of-type {
 	font-size: var(--font-size-300);
+	margin-bottom: var(--size-350);
 }
 
 .c-creator {
 	margin-top: var(--size-300);
 }
 
-.c-creator__bio {
+.c-creator__info {
 	display: flex;
 	margin-top: var(--size-050);
 }
@@ -1812,6 +1813,7 @@ img.u-effect-gold-screen:hover {
 
 .c-creator__read-more {
 	color: var(--color-gold);
+	display: inline;
 	font-weight: var(--type-weight-bold);
 	text-transform: uppercase;
 }

--- a/themes/blankslate-child/tease-project.php
+++ b/themes/blankslate-child/tease-project.php
@@ -26,7 +26,7 @@
 
     <div class="c-creator">
       <h3 class="c-creator__name">
-        <?php echo $temp_filmmaker_name; ?>
+        Filmmaker: <?php echo $temp_filmmaker_name; ?>
       </h3>
       <div class="c-creator__bio">
         <?php if ( ! empty($temp_filmmaker_photo)) : ?>

--- a/themes/blankslate-child/tease-project.php
+++ b/themes/blankslate-child/tease-project.php
@@ -1,9 +1,8 @@
 <?php
-  $video_id = get_field('video_id');
+  $associated_filmmaker = get_field('associated_filmmaker');
+  $page_slug = $post->post_name;
   $transcript = get_field('transcript');
-  $temp_filmmaker_name = get_field('temp_filmmaker_name');
-  $temp_filmmaker_photo = get_field('temp_filmmaker_photo');
-  $temp_filmmaker_bio = get_field('temp_filmmaker_bio');
+  $video_id = get_field('video_id');
 ?>
 
 <div class="c-tease-project">
@@ -21,22 +20,23 @@
   </h2>
 
     <p class="c-tease-project__excerpt">
-      <?php the_excerpt(); ?>
+      <?php echo excerpt(35); ?>
     </p>
 
     <div class="c-creator">
       <h3 class="c-creator__name">
-        Filmmaker: <?php echo $temp_filmmaker_name; ?>
+        Filmmaker: <?php echo esc_html( $associated_filmmaker->post_title ); ?>
       </h3>
-      <div class="c-creator__bio">
-        <?php if ( ! empty($temp_filmmaker_photo)) : ?>
-          <img
-            alt="Photo of <?php echo $temp_filmmaker_name; ?>."
-            class="c-creator__photo"
-            src="<?php echo $temp_filmmaker_photo['url']; ?>">
-        <?php endif; ?>
+      <div class="c-creator__info">
+        <img
+          alt="Photo of <?php echo esc_html( $associated_filmmaker->post_title ); ?>."
+          class="c-creator__photo"
+          src="<?php echo get_the_post_thumbnail($associated_filmmaker, 'large'); ?>
         <div class="c-creator__bio">
-          <?php echo $temp_filmmaker_bio; ?>
+          <?php echo esc_html( $associated_filmmaker->post_excerpt ); ?>&nbsp;
+          <a class="c-creator__read-more" href="/filmmakers/#<?php echo sanitize_title( $associated_filmmaker->post_title ) ?>">
+            Read&nbsp;more<span class="screen-reader-text"> about <?php echo esc_html( $associated_filmmaker->post_title ); ?></span>
+          </a>
         </div>
       </div>
     </div>

--- a/themes/blankslate-child/update-banner.php
+++ b/themes/blankslate-child/update-banner.php
@@ -1,7 +1,7 @@
 <?php if ( ! empty($new_video)) : ?>
   <div class="c-update-banner">
     <p id="title" class="c-update-banner__message">
-      Documentaries<span class="screen-reader-text">:</span> <span class="u-color-text-gray-brick"><?php echo $new_video; ?><span class="screen-reader-text">.</span></span>
+      Documentaries <span class="u-color-text-gray-brick"><?php echo $new_video; ?></span>
     </p>
   </div>
 <?php endif; ?>

--- a/themes/blankslate-child/update-banner.php
+++ b/themes/blankslate-child/update-banner.php
@@ -1,7 +1,7 @@
 <?php if ( ! empty($new_video)) : ?>
   <div class="c-update-banner">
-    <p id="title" class="c-update-banner__message">
+    <h1 id="title" class="c-update-banner__message">
       Documentaries <span class="u-color-text-gray-brick"><?php echo $new_video; ?></span>
-    </p>
+    </h1>
   </div>
 <?php endif; ?>


### PR DESCRIPTION
This PR makes **significant** updates to films and filmmakers.

Filmmakers:

- Remove the Filmmaker Photo custom field 
- Use Wordpress' Featured image functionality to display filmmaker photos
- Use Wordpress' excerpt functionality to display a short version of the filmmaker bio

Films:

- Remove the temporary filmmaker image, name, and bio custom fields
- Add the ability to use associated filmmaker info with the film

Filmmakers page:

- The "Read more" link for a filmmaker on a project tease links to the associated filmmaker on the Filmmakers page