### PR TITLE
Update news tease container grid

### DIFF
--- a/themes/blankslate-child/recent-news.php
+++ b/themes/blankslate-child/recent-news.php
@@ -1,0 +1,18 @@
+<div class="l-tease-news">
+  <h2 class="l-tease-news__title">
+    News <span class="u-color-text-gray-brick">From the Global Frontlines of Disability Justice</span>
+  </h2>
+  <div class="l-tease-news__posts">
+    <?php
+      $args = array(
+        'category_name' => 'news',
+        'posts_per_page' => 3,
+        'no_found_rows' => true
+      );
+      $query = new WP_Query($args);
+
+      while($query -> have_posts()) : $query -> the_post(); ?>
+        <?php get_template_part('tease-news'); ?>
+    <?php endwhile; ?>
+  </div>
+</div>

--- a/themes/blankslate-child/sass/components/_accessibility-modal.scss
+++ b/themes/blankslate-child/sass/components/_accessibility-modal.scss
@@ -21,7 +21,7 @@ $_modal-icon-size: var(--size-600);
     grid-template-columns: 1fr 1fr;
   }
 
-  @media (min-width: $breakpoint-medium) {
+  @media (min-width: $breakpoint-700) {
     grid-template-columns: 1fr 1fr 1fr 1fr;
   }
 }

--- a/themes/blankslate-child/sass/components/_accessibility-settings.scss
+++ b/themes/blankslate-child/sass/components/_accessibility-settings.scss
@@ -17,7 +17,7 @@ $_toggle-icon-size: var(--size-500);
     }
   }
 
-  @media (min-width: $breakpoint-medium) {
+  @media (min-width: $breakpoint-700) {
     flex-direction: row;
   }
 }
@@ -29,7 +29,7 @@ $_toggle-icon-size: var(--size-500);
   pointer-events: none; // Allows click through to toggle modal button. SEE: https://github.com/scottaohara/accessible_modal_window/issues/24
   width: $_toggle-icon-size;
 
-  @media (min-width: $breakpoint-medium) {
+  @media (min-width: $breakpoint-700) {
     margin-right: var(--size-100);
   }
 }
@@ -44,7 +44,7 @@ $_toggle-icon-size: var(--size-500);
   pointer-events: none; // Allows click through to toggle modal button. SEE: https://github.com/scottaohara/accessible_modal_window/issues/24
   text-decoration: none;
 
-  @media (min-width: $breakpoint-medium) {
+  @media (min-width: $breakpoint-700) {
   }
 }
 
@@ -52,7 +52,7 @@ $_toggle-icon-size: var(--size-500);
 .c-accessibility-settings__phrase-switch {
   display: none;
 
-  @media (min-width: $breakpoint-medium) {
+  @media (min-width: $breakpoint-700) {
     display: initial;
   }
 }

--- a/themes/blankslate-child/sass/components/_footer.scss
+++ b/themes/blankslate-child/sass/components/_footer.scss
@@ -2,7 +2,7 @@
   font-size: var(--size-300);
   padding: var(--size-300) var(--size-200) 0 var(--size-200);
 
-  @media (min-width: $breakpoint-medium) {
-    padding: 0;
+  @media (min-width: $breakpoint-700) {
+    @include homepage-inset("margin", "right");
   }
 }

--- a/themes/blankslate-child/sass/components/_tease-project.scss
+++ b/themes/blankslate-child/sass/components/_tease-project.scss
@@ -5,11 +5,11 @@
 
   &:nth-of-type(n+3) .c-tease-project__video {
     @media (min-width: $breakpoint-500) {
-      margin-left: var(--size-900); // SEE: _update-banner.scss
+      @include homepage-inset("margin", "left");
     }
   }
 
-  @media (min-width: $breakpoint-medium) {
+  @media (min-width: $breakpoint-700) {
     display: grid;
     grid-template-columns: 1.5fr 1fr;
   }
@@ -17,7 +17,7 @@
 
 
 .c-tease-project__video {
-  @media (min-width: $breakpoint-medium) {
+  @media (min-width: $breakpoint-700) {
     margin-bottom: var(--size-200);
   }
 }
@@ -27,10 +27,10 @@
   margin-right: var(--size-300);
   margin-left: var(--size-300);
 
-  @media (min-width: $breakpoint-medium) {
+  @media (min-width: $breakpoint-700) {
     align-self: end;
     margin: 0 0 var(--size-200) 0;
-    padding-right: 6rem;
+    padding-right: var(--size-950);
     padding-left: var(--font-size-600);
   }
 }

--- a/themes/blankslate-child/sass/components/_update-banner.scss
+++ b/themes/blankslate-child/sass/components/_update-banner.scss
@@ -2,7 +2,7 @@
   margin-left: var(--size-200);
 
   @media (min-width: $breakpoint-500) {
-    margin-left: var(--size-900); // SEE: _tease-project.scss
+    @include homepage-inset("margin", "left");
   }
 }
 

--- a/themes/blankslate-child/sass/layouts/_footer.scss
+++ b/themes/blankslate-child/sass/layouts/_footer.scss
@@ -2,10 +2,10 @@
   border-top: var(--border-thin) solid var(--color-gray-light);
   display: flex;
   flex-direction: column;
-  padding: var(--size-500) var(--size-400) var(--size-400) 0;
+  padding: var(--size-500) 0 var(--size-400) 0;
   justify-content: space-between;
 
-  @media (min-width: $breakpoint-medium) {
+  @media (min-width: $breakpoint-700) {
     align-items: flex-end;
     flex-direction: row;
   }

--- a/themes/blankslate-child/sass/layouts/_tease-news.scss
+++ b/themes/blankslate-child/sass/layouts/_tease-news.scss
@@ -5,12 +5,16 @@
 
   @media (min-width: $breakpoint-300) {
     display: grid;
-    grid-template-columns: 0.1fr 1fr 0.1fr;
+    grid-template-columns: 1fr;
     grid-template-rows: auto;
     grid-template-areas:
-      '. title .'
-      '. news  .';
-    padding: var(--size-800) 0 5rem 0;
+      'title'
+      'news';
+    padding: var(--size-800) var(--size-200) 5rem var(--size-200);
+  }
+
+  @media (min-width: $breakpoint-500) {
+    @include homepage-inset("padding", "both");
   }
 }
 

--- a/themes/blankslate-child/sass/logic/_mixin.homepage-inset.scss
+++ b/themes/blankslate-child/sass/logic/_mixin.homepage-inset.scss
@@ -1,0 +1,15 @@
+@mixin homepage-inset($property, $location) {
+  @if ($location == "left") {
+    #{$property}-left: var(--size-900);
+  }
+  @else if ($location == "right") {
+    #{$property}-right: var(--size-900);
+  }
+  @else if ($location == "both") {
+    #{$property}-left: var(--size-900);
+    #{$property}-right: var(--size-900);
+  }
+  @else {
+    @error "Please use an argument of `left`, `right`, or `both`."
+  }
+}

--- a/themes/blankslate-child/sass/logic/_variables.breakpoints.scss
+++ b/themes/blankslate-child/sass/logic/_variables.breakpoints.scss
@@ -1,5 +1,4 @@
 $breakpoint-small: 62rem;
-$breakpoint-medium: 70rem;
 
 $breakpoint-100: 10em;
 $breakpoint-200: 20em;

--- a/themes/blankslate-child/sass/style.scss
+++ b/themes/blankslate-child/sass/style.scss
@@ -27,6 +27,7 @@ Text Domain: blankslate-child
 @import "logic/variables.breakpoints";
 @import "logic/variables.colors";
 @import "logic/mixin.column-width";
+@import "logic/mixin.homepage-inset";
 
 
 // Base

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -1150,11 +1150,11 @@ img.u-effect-gold-screen:hover {
 	border-top: var(--border-thin) solid var(--color-gray-light);
 	display: flex;
 	flex-direction: column;
-	padding: var(--size-500) var(--size-400) var(--size-400) 0;
+	padding: var(--size-500) 0 var(--size-400) 0;
 	justify-content: space-between;
 }
 
-@media (min-width: 70rem) {
+@media (min-width: 70em) {
 	.l-footer {
 		align-items: flex-end;
 		flex-direction: row;
@@ -1344,10 +1344,17 @@ img.u-effect-gold-screen:hover {
 @media (min-width: 30em) {
 	.l-tease-news {
 		display: grid;
-		grid-template-columns: 0.1fr 1fr 0.1fr;
+		grid-template-columns: 1fr;
 		grid-template-rows: auto;
-		grid-template-areas: '. title .' '. news  .';
-		padding: var(--size-800) 0 5rem 0;
+		grid-template-areas: 'title' 'news';
+		padding: var(--size-800) var(--size-200) 5rem var(--size-200);
+	}
+}
+
+@media (min-width: 50em) {
+	.l-tease-news {
+		padding-left: var(--size-900);
+		padding-right: var(--size-900);
 	}
 }
 
@@ -1563,7 +1570,7 @@ img.u-effect-gold-screen:hover {
 	}
 }
 
-@media (min-width: 70rem) {
+@media (min-width: 70em) {
 	.c-accessibility-modal__wrapper {
 		grid-template-columns: 1fr 1fr 1fr 1fr;
 	}
@@ -1675,7 +1682,7 @@ img.u-effect-gold-screen:hover {
 	color: var(--color-white);
 }
 
-@media (min-width: 70rem) {
+@media (min-width: 70em) {
 	.c-accessibility-settings__toggle {
 		flex-direction: row;
 	}
@@ -1689,7 +1696,7 @@ img.u-effect-gold-screen:hover {
 	width: var(--size-500);
 }
 
-@media (min-width: 70rem) {
+@media (min-width: 70em) {
 	.c-accessibility-settings__toggle-icon {
 		margin-right: var(--size-100);
 	}
@@ -1709,7 +1716,7 @@ img.u-effect-gold-screen:hover {
 	display: none;
 }
 
-@media (min-width: 70rem) {
+@media (min-width: 70em) {
 	.c-accessibility-settings__phrase-switch {
 		display: initial;
 	}
@@ -1887,9 +1894,9 @@ img.u-effect-gold-screen:hover {
 	padding: var(--size-300) var(--size-200) 0 var(--size-200);
 }
 
-@media (min-width: 70rem) {
+@media (min-width: 70em) {
 	.c-footer__tagline {
-		padding: 0;
+		margin-right: var(--size-900);
 	}
 }
 
@@ -2149,14 +2156,14 @@ a:focus .c-logo #logotype {
 	}
 }
 
-@media (min-width: 70rem) {
+@media (min-width: 70em) {
 	.c-tease-project {
 		display: grid;
 		grid-template-columns: 1.5fr 1fr;
 	}
 }
 
-@media (min-width: 70rem) {
+@media (min-width: 70em) {
 	.c-tease-project__video {
 		margin-bottom: var(--size-200);
 	}
@@ -2168,11 +2175,11 @@ a:focus .c-logo #logotype {
 	margin-left: var(--size-300);
 }
 
-@media (min-width: 70rem) {
+@media (min-width: 70em) {
 	.c-tease-project__content {
 		align-self: end;
 		margin: 0 0 var(--size-200) 0;
-		padding-right: 6rem;
+		padding-right: var(--size-950);
 		padding-left: var(--font-size-600);
 	}
 }

--- a/themes/blankslate-child/template-homepage.php
+++ b/themes/blankslate-child/template-homepage.php
@@ -28,24 +28,7 @@
     <?php get_template_part('tease-project'); ?>
 <?php endwhile; ?>
 
-<div class="l-tease-news">
-  <h2 class="l-tease-news__title">
-    News <span class="u-color-text-gray-brick">From the Global Frontlines of Disability Justice</span>
-  </h2>
-  <div class="l-tease-news__posts">
-    <?php
-      $args = array(
-        'category_name' => 'news',
-        'posts_per_page' => 3,
-        'no_found_rows' => true
-      );
-      $query = new WP_Query($args);
-
-      while($query -> have_posts()) : $query -> the_post(); ?>
-        <?php get_template_part('tease-news'); ?>
-    <?php endwhile; ?>
-  </div>
-</div>
+<?php get_template_part('recent-news');?>
 
 </main>
 

--- a/themes/blankslate-child/template-news.php
+++ b/themes/blankslate-child/template-news.php
@@ -62,24 +62,7 @@
 
 
   </div>
-  <div class="l-tease-news">
-    <h2 class="l-tease-news__title">
-      News <span class="u-color-text-gray-brick">From the Global Frontlines of Disability Justice</span>
-    </h2>
-    <div class="l-tease-news__posts">
-      <?php
-        $args = array(
-          'category_name' => 'news',
-          'posts_per_page' => 3,
-          'no_found_rows' => true
-        );
-        $query = new WP_Query($args);
-
-        while($query -> have_posts()) : $query -> the_post(); ?>
-          <?php get_template_part('tease-news'); ?>
-      <?php endwhile; ?>
-    </div>
-  </div>
+  <?php get_template_part('recent-news');?>
 </main>
 
 <?php get_footer(); ?>


### PR DESCRIPTION
This PR aligns the news post teases container to the homepage grid. It also consolidates the tease container to use a single partial, and removes the older `$breakpoint-small` in favor of the updated breakpoint syntax.