### PR TITLE
Initial dynamic accessibility settings work

### DIFF
--- a/themes/blankslate-child/accessibility-settings-modal.php
+++ b/themes/blankslate-child/accessibility-settings-modal.php
@@ -21,17 +21,17 @@
           <legend class="screen-reader-text">Set type size</legend>
           <label for="font-size-default">
             <span class="c-accessibility-modal__label">Default</span>
-            <input id="font-size-default" class="c-accessibility-modal__radio" name="font-size" type="radio">
+            <input id="font-size-default" class="c-accessibility-modal__radio" name="font-size" value="font-size-default" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" height="52" width="52" viewBox="0 0 52 52"><circle cx="26" cy="26" r="26"/><circle cx="26" cy="26" r="24" fill="none" stroke="#000" stroke-width="4"/><g><path d="M25 20.8h2.4l4 10.9h-2.2l-1-2.9h-4.1l-1 2.9H21l4-10.9zm-.4 6.2h2.9l-1.4-4-1.5 4z" fill="#fff"/></g></svg>
           </label>
           <label for="font-size-large">
             <span class="c-accessibility-modal__label">Large</span>
-            <input id="font-size-large" class="c-accessibility-modal__radio" name="font-size" type="radio">
+            <input id="font-size-large" class="c-accessibility-modal__radio" name="font-size" value="font-size-large" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" height="52" width="52" viewBox="0 0 52 52"><circle cx="26" cy="26.2" r="26"/><circle cx="26" cy="26.2" r="24" fill="none" stroke="#000" stroke-width="4"/><g><path d="M23.5 14.5h5.1l8.5 23.4h-4.8l-2.2-6.2h-8.8L19 37.9h-4.4l8.9-23.4zM22.7 28H29l-3.1-8.7-3.2 8.7z" fill="#fff"/></g></svg>
           </label>
           <label for="font-size-extra-large">
             <span class="c-accessibility-modal__label">Extra Large</span>
-            <input id="font-size-extra-large" class="c-accessibility-modal__radio" name="font-size" type="radio">
+            <input id="font-size-extra-large" class="c-accessibility-modal__radio" name="font-size" value="font-size-extra-large" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" height="52" width="52" viewBox="0 0 52 52"><circle cx="26" cy="26" r="26"/><circle cx="26" cy="26" r="24" fill="none" stroke="#000" stroke-width="4"/><g><path d="M23.3 11.1H29L38.4 37h-5.3l-2.5-6.9h-9.7L18.4 37h-4.9l9.8-25.9zM22.4 26h6.9l-3.4-9.6-3.5 9.6z" fill="#fff"/></g></svg>
           </label>
         </fieldset>
@@ -44,17 +44,17 @@
           <legend class="screen-reader-text">Set type size</legend>
           <label for="line-height-default">
             <span class="c-accessibility-modal__label">Default</span>
-            <input id="line-height-default" class="c-accessibility-modal__radio" name="line-height" type="radio">
+            <input id="line-height-default" class="c-accessibility-modal__radio" name="line-height" value="line-height-default" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 52 52" xml:space="preserve"><style>.st2{fill:none;stroke:#707071;stroke-width:3}</style><g id="Group_105"><g id="Ellipse_8" fill="none"><circle cx="26" cy="26" r="26"/><circle cx="26" cy="26" r="24" stroke="#000" stroke-width="4"/></g></g><path id="Line_38" class="st2" d="M15.5 23h22"/><path id="Line_39" class="st2" d="M15.5 29h22"/></svg>
           </label>
           <label for="line-height-more">
             <span class="c-accessibility-modal__label">More</span>
-            <input id="line-height-more" class="c-accessibility-modal__radio" name="line-height" type="radio">
+            <input id="line-height-more" class="c-accessibility-modal__radio" name="line-height" value="line-height-more" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52"><defs><style>.cls-3{fill:none;stroke:#707071;stroke-width:3px}</style></defs><g id="Group_106" data-name="Group 106"><g id="Ellipse_8" data-name="Ellipse 8" fill="none"><circle cx="26" cy="26" r="26"/><circle cx="26" cy="26" r="24" stroke="#000" stroke-width="4"/></g></g><path id="Line_41" data-name="Line 41" class="cls-3" d="M15.5 19h22"/><path id="Line_40" data-name="Line 40" class="cls-3" d="M15.5 33h22"/></svg>
           </label>
           <label for="line-height-max">
             <span class="c-accessibility-modal__label">Max</span>
-            <input id="line-height-max" class="c-accessibility-modal__radio" name="line-height" type="radio">
+            <input id="line-height-max" class="c-accessibility-modal__radio" name="line-height" value="line-height-max" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 52 52" xml:space="preserve"><style>.st2{fill:none;stroke:#707071;stroke-width:3}</style><g id="Group_107"><g id="Ellipse_8" fill="none"><circle cx="26" cy="26" r="26"/><circle cx="26" cy="26" r="24" stroke="#000" stroke-width="4"/></g></g><path id="Line_43" class="st2" d="M15.5 14h22"/><path id="Line_42" class="st2" d="M15.5 38h22"/></svg>
           </label>
         </fieldset>
@@ -67,22 +67,22 @@
           <legend class="screen-reader-text">Adjust contrast</legend>
           <label for="contrast-default">
             <span class="c-accessibility-modal__label">Default</span>
-            <input id="contrast-default" class="c-accessibility-modal__radio" name="contrast" type="radio">
+            <input id="contrast-default" class="c-accessibility-modal__radio" name="contrast" value="contrast-default" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 53"><ellipse cx="26" cy="26.5" rx="26" ry="26.5"/><ellipse cx="26" cy="26.5" rx="24" ry="24.5" fill="none" stroke="#000" stroke-width="4"/><g><path d="M23.3 11.1H29L38.4 37h-5.3l-2.5-6.9h-9.7L18.4 37h-4.9l9.8-25.9zM22.4 26h6.9l-3.4-9.6-3.5 9.6z" fill="#fff"/></g></svg>
           </label>
           <label for="contrast-yellow">
             <span class="c-accessibility-modal__label">Yellow</span>
-            <input id="contrast-yellow" class="c-accessibility-modal__radio" name="contrast" type="radio">
+            <input id="contrast-yellow" class="c-accessibility-modal__radio" name="contrast" value="contrast-yellow" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 53"><ellipse cx="27" cy="26.5" rx="27" ry="26.5" fill="#ffe300"/><ellipse cx="27" cy="26.5" rx="25" ry="24.5" fill="none" stroke="#000" stroke-width="4"/><g><path d="M24.8 10.8h5.9l10 27.2h-5.5l-2.6-7.3H22.3L19.7 38h-5.2l10.3-27.2zm-1 15.6h7.3l-3.6-10.1-3.7 10.1z"/></g></svg>
           </label>
           <label for="contrast-white">
             <span class="c-accessibility-modal__label">White</span>
-            <input id="contrast-white" class="c-accessibility-modal__radio" name="contrast" type="radio">
+            <input id="contrast-white" class="c-accessibility-modal__radio" name="contrast" value="contrast-white" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 53"><path d="M24.8 10.8h5.9l10 27.2h-5.5l-2.6-7.3H22.3L19.7 38h-5.2l10.3-27.2zm-1 15.6h7.3l-3.6-10.1-3.7 10.1z"/><g fill="none"><ellipse cx="27" cy="26.5" rx="27" ry="26.5"/><ellipse cx="27" cy="26.5" rx="25" ry="24.5" stroke="#000" stroke-width="4"/></g></svg>
           </label>
           <label for="contrast-blue">
             <span class="c-accessibility-modal__label">Blue</span>
-            <input id="contrast-blue" class="c-accessibility-modal__radio" name="contrast" type="radio">
+            <input id="contrast-blue" class="c-accessibility-modal__radio" name="contrast" value="contrast-blue" type="radio">
             <svg class="c-accessibility-modal__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 53"><path d="M27 51c-3.3 0-6.7-.6-9.8-1.9-3-1.2-5.7-3-7.9-5.3-9.6-9.3-9.8-24.6-.5-34.2.2-.1.4-.3.5-.4 2.3-2.3 5-4 7.9-5.3 6.2-2.6 13.2-2.6 19.5 0 5.9 2.5 10.7 7.1 13.3 13 2.6 6.1 2.6 12.9 0 19-1.3 2.9-3.1 5.6-5.3 7.8C40 48.3 33.6 50.9 27 51z" fill="#caecf6"/><path d="M27 4c-3.1 0-6.1.6-9 1.8-2.7 1.1-5.2 2.8-7.3 4.8-2.1 2-3.8 4.5-4.9 7.2-2.4 5.6-2.4 11.9 0 17.5 1.2 2.7 2.8 5.1 4.9 7.2 2.1 2.1 4.6 3.7 7.3 4.8 8.6 3.6 18.6 1.7 25.3-4.8 2.1-2 3.8-4.5 4.9-7.2 2.4-5.6 2.4-11.9 0-17.5-1.2-2.7-2.8-5.1-4.9-7.2C38.9 6.4 33.1 4 27 4m0-4c14.6.3 26.3 12.4 26 27-.3 14.6-12.4 26.3-27 26-14.5-.3-26-12.1-26-26.5C.1 11.7 12.2-.1 27 0z"/><g><path d="M24.8 10.8h5.9l10 27.2h-5.5l-2.6-7.3H22.3L19.7 38h-5.2l10.3-27.2zm-1 15.6h7.3l-3.6-10.1-3.7 10.1z"/></g></svg>
           </label>
         </fieldset>
@@ -95,12 +95,12 @@
           <legend class="screen-reader-text">Highlight style</legend>
           <label for="no-highlight">
             <span class="c-accessibility-modal__label">No highlight</span>
-            <input id="no-highlight" class="c-accessibility-modal__radio" name="highlight-style" type="radio">
+            <input id="no-highlight" class="c-accessibility-modal__radio" name="highlight-style" value="no-highlight" type="radio">
             <svg class="c-accessibility-modal__button" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 154 45"><g data-name="Rectangle 27"><path d="M0 0h154v45H0z"/><path fill="none" stroke="#707070" d="M.5.5h153v44H.5z"/></g></svg>
           </label>
           <label for="highlighted">
             <span class="c-accessibility-modal__label">Highlighted</span>
-            <input id="highlighted" class="c-accessibility-modal__radio" name="highlight-style" type="radio">
+            <input id="highlighted" class="c-accessibility-modal__radio" name="highlight-style" value="highlighted" type="radio">
             <svg class="c-accessibility-modal__button" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 154 54"><g data-name="Rectangle 28"><path d="M0 0h154v54H0z"/><path fill="none" stroke="#ffe300" stroke-width="12" d="M6 6h142v42H6z"/></g></svg>
           </label>
         </fieldset>
@@ -108,7 +108,7 @@
     </div>
     <div class="c-accessibility-modal__commit">
       <button data-modal-close-button class="c-accessibility-modal__control" type="button">Cancel</button>
-      <button data-modal-close-button class="c-accessibility-modal__control" type="button">Restore default</button>
+      <button data-modal-button-reset class="c-accessibility-modal__control" type="button">Restore default</button>
       <button data-modal-close-button class="c-accessibility-modal__control c-accessibility-modal__control--primary" type="button">Save</button>
     </div>
   </section>

--- a/themes/blankslate-child/js/main.js
+++ b/themes/blankslate-child/js/main.js
@@ -1,25 +1,5 @@
 (function($) {
 
-  // Toggle accessibility settings modal
-  var accessibilitySettingsToggle = $('#accessibility-settings-toggle');
-  var accessibilitySettingsModal = $('#accessibility-settings-modal').hide();
-  var accessibilitySettingsModalTitle = $('#accessibility-settings-modal-title');
-
-  accessibilitySettingsToggle.click(function(event) {
-    if ( accessibilitySettingsModal.attr('hidden') ) {
-      accessibilitySettingsToggle.attr("aria-expanded", "true");
-      accessibilitySettingsModal.removeAttr('hidden');
-      accessibilitySettingsModal.slideDown();
-      accessibilitySettingsModalTitle.focus();
-    } else {
-      accessibilitySettingsModal.prop('hidden', true);
-      accessibilitySettingsModal.hide();
-      accessibilitySettingsToggle.attr("aria-expanded", "false");
-      accessibilitySettingsToggle.focus();
-    }
-    return false;
-  });
-
   // Toggle transcripts
   var transcriptButtons = $('[data-transcript="button"]');
   var transcriptTitle = $('[data-transcript="title"]');
@@ -42,10 +22,84 @@
     return false;
   });
 
+
+
+  // Toggle accessibility settings modal
+  var accessibilitySettingsToggle = $('#accessibility-settings-toggle');
+  var accessibilitySettingsModal = $('#accessibility-settings-modal').hide();
+  var accessibilitySettingsModalTitle = $('#accessibility-settings-modal-title');
+
+  accessibilitySettingsToggle.click(function(event) {
+    if ( accessibilitySettingsModal.attr('hidden') ) {
+      accessibilitySettingsToggle.attr("aria-expanded", "true");
+      accessibilitySettingsModal.removeAttr('hidden');
+      accessibilitySettingsModal.slideDown();
+      accessibilitySettingsModalTitle.focus();
+    } else {
+      accessibilitySettingsModal.prop('hidden', true);
+      accessibilitySettingsModal.hide();
+      accessibilitySettingsToggle.attr("aria-expanded", "false");
+      accessibilitySettingsToggle.focus();
+    }
+    return false;
+  });
+
   var accessibilitySettingsCloseButton = $('[data-modal-close-button]');
   accessibilitySettingsCloseButton.click(function(event) {
     accessibilitySettingsModal.prop('hidden', true);
     return false;
   });
+
+
+  // Check and set defaults
+  var fontSizeDefault = $('#font-size-default').prop("checked", true);
+  var lineHeightDefault = $('#line-height-default').prop("checked", true);
+  var contrastDefault = $('#contrast-default').prop("checked", true);
+  var noHighlight = $('#no-highlight').prop("checked", true);
+  $(document.body).addClass('js-font-size-default js-line-height-default js-contrast-default');
+
+
+  // Toggle font size settings
+  $('input[name="font-size"]').change(function(){
+    var inputVal = $('input[name="font-size"]:checked').val();
+    $(document.body)
+      .removeClass('js-font-size-default js-font-size-large js-font-size-extra-large')
+      .addClass("js-" + inputVal);
+  });
+
+  // Toggle line height settings
+  $('input[name="line-height"]').change(function(){
+    var inputVal = $('input[name="line-height"]:checked').val();
+    $(document.body)
+      .removeClass('js-line-height-default js-line-height-more js-line-height-max')
+      .addClass("js-" + inputVal);
+  });
+
+
+  // Toggle contrast settings
+  $('input[name="contrast"]').change(function(){
+    var inputVal = $('input[name="contrast"]:checked').val();
+    $(document.body)
+      .removeClass('js-contrast-default js-contrast-yellow js-contrast-white js-contrast-blue')
+      .addClass("js-" + inputVal);
+  });
+
+  // Toggle highlight style settings
+  $('input[name="highlight-style"]').change(function(){
+    var inputVal = $('input[name="highlight-style"]:checked').val();
+    $(document.body)
+      .removeClass('js-no-highlight js-highlighted')
+      .addClass("js-" + inputVal);
+  });
+
+  // Restores default accessibility modal settings
+  var accessibilitySettingsResetButton = $('[data-modal-button-reset]');
+  accessibilitySettingsResetButton.click(function(event) {
+    $(document.body)
+      .removeClass('js-font-size-default js-font-size-large js-font-size-extra-large js-line-height-default js-line-height-more js-line-height-max js-contrast-default js-contrast-yellow js-contrast-white js-contrast-blue js-no-highlight js-highlighted')
+      .addClass('js-font-size-default js-line-height-default js-contrast-default js-no-highlight');
+    return false;
+  });
+
 
 })(jQuery);


### PR DESCRIPTION
This PR:

- Sets default classes on the `body` element, as hooks for future styling.
- Toggles classes on the `body` element when each of the accessibility settings radio groups are interacted with.
- Adds "Restore default" functionality.

Styling work to follow in a subsequent PR.