### PR TITLE
Keep primary nav one row on smallest breakpoint

### DIFF
--- a/themes/blankslate-child/sass/components/_nav-primary.scss
+++ b/themes/blankslate-child/sass/components/_nav-primary.scss
@@ -1,12 +1,9 @@
 .c-nav-primary {
 
   .menu {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-columns: auto auto;
+    display: flex;
 
     @media (min-width: $breakpoint-300) {
-      display: flex;
       margin-left: var(--size-200);
     }
   }
@@ -16,11 +13,15 @@
     list-style-type: none;
     margin-right: var(--size-200);
 
+    &:first-of-type {
+      margin-left: var(--size-200);
+    }
+
     a {
       color: var(--color-white);
       border-bottom: var(--border-thick) solid var(--color-white);
       display: block;
-      font-size: var(--font-size-200);
+      font-size: var(--font-size-100);
       font-weight: var(--type-weight-bold);
       text-decoration: none;
       padding-top: var(--size-150);
@@ -29,6 +30,14 @@
       &:hover,
       &:focus {
         color: var(--color-gold);
+      }
+
+      @media (min-width: $breakpoint-300) {
+        font-size: var(--font-size-200);
+
+        &:first-of-type {
+          margin-left: 0;
+        }
       }
 
       @media (min-width: $breakpoint-500) {

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -2011,14 +2011,11 @@ a:focus .c-logo #logotype {
 }
 
 .c-nav-primary .menu {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	grid-template-columns: auto auto;
+	display: flex;
 }
 
 @media (min-width: 30em) {
 	.c-nav-primary .menu {
-		display: flex;
 		margin-left: var(--size-200);
 	}
 }
@@ -2029,11 +2026,15 @@ a:focus .c-logo #logotype {
 	margin-right: var(--size-200);
 }
 
+.c-nav-primary li:first-of-type {
+	margin-left: var(--size-200);
+}
+
 .c-nav-primary li a {
 	color: var(--color-white);
 	border-bottom: var(--border-thick) solid var(--color-white);
 	display: block;
-	font-size: var(--font-size-200);
+	font-size: var(--font-size-100);
 	font-weight: var(--type-weight-bold);
 	text-decoration: none;
 	padding-top: var(--size-150);
@@ -2042,6 +2043,15 @@ a:focus .c-logo #logotype {
 
 .c-nav-primary li a:hover, .c-nav-primary li a:focus {
 	color: var(--color-gold);
+}
+
+@media (min-width: 30em) {
+	.c-nav-primary li a {
+		font-size: var(--font-size-200);
+	}
+	.c-nav-primary li a:first-of-type {
+		margin-left: 0;
+	}
 }
 
 @media (min-width: 50em) {


### PR DESCRIPTION
This PR updates the primary nav to use a single row on the smallest breakpoints.

<img width="360" alt="ScreenCapture at Mon Jul 12 23:41:09 EDT 2021" src="https://user-images.githubusercontent.com/634191/125386706-bbb26000-e36a-11eb-881e-228e4b06e8d7.png">
