### PR TITLE
Update blue contrast theme background color

### DIFF
--- a/themes/blankslate-child/sass/base/_core.scss
+++ b/themes/blankslate-child/sass/base/_core.scss
@@ -57,7 +57,7 @@ body {
   }
 
   &.js-contrast-blue {
-    background-color: var(--color-dusk);
+    background-color: var(--color-dusk-tint);
     color: var(--color-black);
   }
 

--- a/themes/blankslate-child/sass/base/_root.scss
+++ b/themes/blankslate-child/sass/base/_root.scss
@@ -12,6 +12,7 @@
   --color-gold: #{$color-gold};
   --color-brick: #{$color-brick};
   --color-olive: #{$color-olive};
+  --color-dusk-tint: #{$color-dusk-tint};
   --color-dusk: #{$color-dusk};
   --font-primary: 'Halyard Display', Arial, sans-serif;
   --font-secondary: 'Halyard Text', Arial, sans-serif;

--- a/themes/blankslate-child/sass/components/_content.scss
+++ b/themes/blankslate-child/sass/components/_content.scss
@@ -61,7 +61,7 @@
   padding-top: var(--size-100);
 
   .js-contrast-blue & {
-    color: var(--color-gold);
+    color: var(--color-gray-darkest);
   }
 }
 

--- a/themes/blankslate-child/sass/components/_creator.scss
+++ b/themes/blankslate-child/sass/components/_creator.scss
@@ -38,7 +38,7 @@
   font-weight: var(--type-weight-bold);
 
   .js-contrast-blue & {
-    color: var(--color-white);
+    color: var(--color-gray-darkest);
   }
 }
 
@@ -61,6 +61,16 @@
   &:focus {
     background-color: var(--color-gold);
     color: var(--color-black);
+  }
+
+  .js-contrast-blue & {
+    color: var(--color-gray-darkest);
+
+    &:hover,
+    &:focus {
+      background-color: var(--color-black);
+      color: var(--color-white);
+    }
   }
 
   .js-contrast-white & {

--- a/themes/blankslate-child/sass/components/_headings.scss
+++ b/themes/blankslate-child/sass/components/_headings.scss
@@ -7,4 +7,8 @@
 .c-heading__medium {
   font-family: var(--font-primary);
   font-size: var(--font-size-450);
+
+  .js-contrast-blue & {
+    color: var(--color-white);
+  }
 }

--- a/themes/blankslate-child/sass/components/_recommended-video.scss
+++ b/themes/blankslate-child/sass/components/_recommended-video.scss
@@ -27,10 +27,18 @@
 .c-recommended-video__about-this-video {
   color: var(--color-brick);
   display: inline;
+
+  .js-contrast-blue & {
+    color: var(--color-gray-medium);
+  }
 }
 
 
 .c-recommended-video__excerpt {
   font-size: var(--font-size-200);
   margin-top: var(--size-100);
+
+  .js-contrast-blue & {
+    color: var(--color-white);
+  }
 }

--- a/themes/blankslate-child/sass/components/_tease-news.scss
+++ b/themes/blankslate-child/sass/components/_tease-news.scss
@@ -3,7 +3,7 @@
   padding: var(--size-400);
 
   .js-contrast-blue & {
-    background-color: var(--color-dusk);
+    background-color: var(--color-dusk-tint);
   }
 
   .js-contrast-yellow & {

--- a/themes/blankslate-child/sass/components/_tease-news.scss
+++ b/themes/blankslate-child/sass/components/_tease-news.scss
@@ -1,14 +1,6 @@
 .c-tease-news {
   background-color: var(--color-white);
   padding: var(--size-400);
-
-  .js-contrast-blue & {
-    background-color: var(--color-dusk-tint);
-  }
-
-  .js-contrast-yellow & {
-    background-color: var(--color-gold);
-  }
 }
 
 
@@ -32,13 +24,6 @@
   &:focus {
     color: var(--color-brick);
     text-decoration: underline;
-  }
-
-  .js-contrast-blue & {
-    &:hover,
-    &:focus {
-      color: var(--color-gold);
-    }
   }
 }
 
@@ -68,16 +53,5 @@
   &:focus {
     background-color: var(--color-black);
     color: var(--color-gold);
-  }
-
-  .js-contrast-yellow & {
-    background-color: var(--color-brick);
-    color: var(--color-white);
-
-    &:hover,
-    &:focus {
-      background-color: var(--color-black);
-      color: var(--color-white);
-    }
   }
 }

--- a/themes/blankslate-child/sass/layouts/_landing.scss
+++ b/themes/blankslate-child/sass/layouts/_landing.scss
@@ -111,6 +111,12 @@
 }
 
 
+.l-landing__spacer {
+  grid-column: 1 / 13;
+  min-height: calc(var(--size-900) * 2);
+}
+
+
 .l-recommended-videos {
   background-color: var(--color-gray-darkest);
   grid-column: 1 / 13;

--- a/themes/blankslate-child/sass/logic/_variables.colors.scss
+++ b/themes/blankslate-child/sass/logic/_variables.colors.scss
@@ -9,3 +9,4 @@ $color-gold: #ffe300;
 $color-brick: #da4c27;
 $color-olive: #76c43b;
 $color-dusk: #00a6d3;
+$color-dusk-tint: #caecf6;

--- a/themes/blankslate-child/sass/utilities/_color-text.scss
+++ b/themes/blankslate-child/sass/utilities/_color-text.scss
@@ -37,7 +37,7 @@
   color: var(--color-gold);
 
   .js-contrast-blue & {
-    color: var(--color-white);
+    color: var(--color-gray-darkest);
   }
 
   .js-contrast-white &,

--- a/themes/blankslate-child/sass/utilities/_text-and-background-color.scss
+++ b/themes/blankslate-child/sass/utilities/_text-and-background-color.scss
@@ -3,7 +3,7 @@
   color: var(--color-black);
 
   .js-contrast-blue & {
-    background-color: var(--color-dusk);
+    background-color: var(--color-dusk-tint);
   }
 
   .js-contrast-yellow & {

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -2511,14 +2511,6 @@ a:focus .c-logo #logotype {
 	padding: var(--size-400);
 }
 
-.js-contrast-blue .c-tease-news {
-	background-color: var(--color-dusk-tint);
-}
-
-.js-contrast-yellow .c-tease-news {
-	background-color: var(--color-gold);
-}
-
 .c-tease-news__image {
 	cursor: pointer;
 	width: 100%;
@@ -2537,10 +2529,6 @@ a:focus .c-logo #logotype {
 .c-tease-news__link:hover, .c-tease-news__link:focus {
 	color: var(--color-brick);
 	text-decoration: underline;
-}
-
-.js-contrast-blue .c-tease-news__link:hover, .js-contrast-blue .c-tease-news__link:focus {
-	color: var(--color-gold);
 }
 
 .c-tease-news__excerpt {
@@ -2573,16 +2561,6 @@ a:focus .c-logo #logotype {
 .c-tease-news__read-more:hover, .c-tease-news__read-more:focus {
 	background-color: var(--color-black);
 	color: var(--color-gold);
-}
-
-.js-contrast-yellow .c-tease-news__read-more {
-	background-color: var(--color-brick);
-	color: var(--color-white);
-}
-
-.js-contrast-yellow .c-tease-news__read-more:hover, .js-contrast-yellow .c-tease-news__read-more:focus {
-	background-color: var(--color-black);
-	color: var(--color-white);
 }
 
 .c-tease-project {

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -410,6 +410,7 @@ figure {
 	--color-gold: #ffe300;
 	--color-brick: #da4c27;
 	--color-olive: #76c43b;
+	--color-dusk-tint: #caecf6;
 	--color-dusk: #00a6d3;
 	--font-primary: 'Halyard Display', Arial, sans-serif;
 	--font-secondary: 'Halyard Text', Arial, sans-serif;
@@ -586,7 +587,7 @@ body.js-font-size-extra-large {
 }
 
 body.js-contrast-blue {
-	background-color: var(--color-dusk);
+	background-color: var(--color-dusk-tint);
 	color: var(--color-black);
 }
 
@@ -1184,7 +1185,7 @@ table tfoot tr td {
 }
 
 .js-contrast-blue .u-color-text-gold {
-	color: var(--color-white);
+	color: var(--color-gray-darkest);
 }
 
 .js-contrast-white .u-color-text-gold,
@@ -1252,7 +1253,7 @@ img.u-effect-gold-screen:hover {
 }
 
 .js-contrast-blue .u-dark-on-light {
-	background-color: var(--color-dusk);
+	background-color: var(--color-dusk-tint);
 }
 
 .js-contrast-yellow .u-dark-on-light {
@@ -1490,6 +1491,11 @@ img.u-effect-gold-screen:hover {
 	.l-landing__section {
 		margin-top: var(--size-900);
 	}
+}
+
+.l-landing__spacer {
+	grid-column: 1 / 13;
+	min-height: calc(var(--size-900) * 2);
 }
 
 .l-recommended-videos {
@@ -2052,7 +2058,7 @@ img.u-effect-gold-screen:hover {
 }
 
 .js-contrast-blue .c-content__topic {
-	color: var(--color-gold);
+	color: var(--color-gray-darkest);
 }
 
 .c-content--project {
@@ -2105,7 +2111,7 @@ img.u-effect-gold-screen:hover {
 }
 
 .js-contrast-blue .c-creator__about-this-video {
-	color: var(--color-white);
+	color: var(--color-gray-darkest);
 }
 
 .c-creator__bio {
@@ -2131,6 +2137,15 @@ img.u-effect-gold-screen:hover {
 .c-creator__read-more:hover, .c-creator__read-more:focus {
 	background-color: var(--color-gold);
 	color: var(--color-black);
+}
+
+.js-contrast-blue .c-creator__read-more {
+	color: var(--color-gray-darkest);
+}
+
+.js-contrast-blue .c-creator__read-more:hover, .js-contrast-blue .c-creator__read-more:focus {
+	background-color: var(--color-black);
+	color: var(--color-white);
 }
 
 .js-contrast-white .c-creator__read-more {
@@ -2159,6 +2174,10 @@ img.u-effect-gold-screen:hover {
 .c-heading__medium {
 	font-family: var(--font-primary);
 	font-size: var(--font-size-450);
+}
+
+.js-contrast-blue .c-heading__medium {
+	color: var(--color-white);
 }
 
 .c-footer__tagline {
@@ -2367,9 +2386,17 @@ a:focus .c-logo #logotype {
 	display: inline;
 }
 
+.js-contrast-blue .c-recommended-video__about-this-video {
+	color: var(--color-gray-medium);
+}
+
 .c-recommended-video__excerpt {
 	font-size: var(--font-size-200);
 	margin-top: var(--size-100);
+}
+
+.js-contrast-blue .c-recommended-video__excerpt {
+	color: var(--color-white);
 }
 
 .c-share__facebook,
@@ -2485,7 +2512,7 @@ a:focus .c-logo #logotype {
 }
 
 .js-contrast-blue .c-tease-news {
-	background-color: var(--color-dusk);
+	background-color: var(--color-dusk-tint);
 }
 
 .js-contrast-yellow .c-tease-news {

--- a/themes/blankslate-child/template-about.php
+++ b/themes/blankslate-child/template-about.php
@@ -45,6 +45,7 @@
           <?php get_template_part('mentor'); ?>
       <?php endwhile; ?>
 
+      <div class="l-landing__spacer"></div>
   </div>
 </main>
 

--- a/themes/blankslate-child/template-filmmakers.php
+++ b/themes/blankslate-child/template-filmmakers.php
@@ -29,6 +29,7 @@
         <?php get_template_part('filmmaker'); ?>
     <?php endwhile; ?>
 
+    <div class="l-landing__spacer"></div>
   </div>
 </main>
 

--- a/themes/blankslate-child/template-resources.php
+++ b/themes/blankslate-child/template-resources.php
@@ -25,6 +25,7 @@
       </div>
     </div>
 
+    <div class="l-landing__spacer"></div>
   </div>
 </main>
 


### PR DESCRIPTION
This PR updates the blue contrast theme background color. It also adds spacing for landing pages that don't have a component immediately following it.

<img width="1468" alt="ScreenCapture at Sun Jul 18 15:01:53 EDT 2021" src="https://user-images.githubusercontent.com/634191/126079232-93435cc7-ca85-4c49-bc1a-947886dc173b.png">

@danzedek I could use some guidance on the gray value used for  "by" and "about", "About this video, etc. for the blue contrast theme. We're running into some color contrast issues here. Do you think brick would work?