### PR TITLE
Persist user selections for the accessibility settings modal

### DIFF
--- a/themes/blankslate-child/accessibility-settings-modal.php
+++ b/themes/blankslate-child/accessibility-settings-modal.php
@@ -107,7 +107,6 @@
       </div>
     </div>
     <div class="c-accessibility-modal__commit">
-      <button data-modal-close-button class="c-accessibility-modal__control" type="button">Cancel</button>
       <button data-modal-button-reset class="c-accessibility-modal__control" type="button">Restore default</button>
       <button data-modal-close-button class="c-accessibility-modal__control c-accessibility-modal__control--primary" type="button">Save</button>
     </div>

--- a/themes/blankslate-child/js/main.js
+++ b/themes/blankslate-child/js/main.js
@@ -1,17 +1,33 @@
 (function($) {
 
-  const DEFAULT_USER_SETTINGS = 'js-font-size-default js-line-height-default js-contrast-default';
+  // Set up defauls
+  const DEFAULT_USER_SETTINGS = 'js-font-size-default js-line-height-default js-contrast-default js-no-highlight';
   const ALL_USER_SETTINGS_CLASSES = 'js-font-size-default js-font-size-large js-font-size-extra-large js-line-height-default js-line-height-more js-line-height-max js-contrast-default js-contrast-yellow js-contrast-white js-contrast-blue js-no-highlight js-highlighted';
   const USER_SETTINGS_KEY = 'userSettings';
   const BODY_EL = $('body');
 
+
+  // Retrieves `js-` classes from the `body` element
   function getUserSettingsFromBody () {
     return BODY_EL[0].className.split(' ').filter((cls) => cls.match(/js\-/)).join(' ');
   }
 
+
+  // Pushes updated settings to LocalStorage
   function updateUserSettings () {
-    localStorage.setItem(USER_SETTINGS_KEY, getUserSettingsFromBody());
+    const userSettings = getUserSettingsFromBody()
+    localStorage.setItem(USER_SETTINGS_KEY, userSettings);
+    return userSettings;
   }
+
+
+  // Toggles inputs
+  function toggleSettingsInputs (userSettings) {
+    userSettings.split(' ')
+      .map((cls) => /js-(.*)/.exec(cls)[1])
+      .forEach((elId) => $('#' + elId).prop('checked', true));
+  }
+
 
   // Toggle transcripts
   var transcriptButtons = $('[data-transcript="button"]');
@@ -36,7 +52,6 @@
   });
 
 
-
   // Toggle accessibility settings modal
   var accessibilitySettingsToggle = $('#accessibility-settings-toggle');
   var accessibilitySettingsModal = $('#accessibility-settings-modal').hide();
@@ -57,6 +72,8 @@
     return false;
   });
 
+
+  // Toggle close button
   var accessibilitySettingsCloseButton = $('[data-modal-close-button]');
   accessibilitySettingsCloseButton.click(function(event) {
     accessibilitySettingsModal.prop('hidden', true);
@@ -65,16 +82,15 @@
 
 
   // Check and set defaults
-  var fontSizeDefault = $('#font-size-default').prop("checked", true);
-  var lineHeightDefault = $('#line-height-default').prop("checked", true);
-  var contrastDefault = $('#contrast-default').prop("checked", true);
-  var noHighlight = $('#no-highlight').prop("checked", true);
   var userSettings = localStorage.getItem(USER_SETTINGS_KEY);
   if (!userSettings) {
     localStorage.setItem(USER_SETTINGS_KEY, DEFAULT_USER_SETTINGS);
     userSettings = DEFAULT_USER_SETTINGS;
   }
   BODY_EL.toggleClass(userSettings, true);
+
+  toggleSettingsInputs(userSettings);
+
 
   // Toggle font size settings
   $('input[name="font-size"]').change(function(){
@@ -84,6 +100,7 @@
       .addClass("js-" + inputVal);
     updateUserSettings();
   });
+
 
   // Toggle line height settings
   $('input[name="line-height"]').change(function(){
@@ -104,7 +121,8 @@
     updateUserSettings();
   });
 
-  // Toggle highlight Cstyle settings
+
+  // Toggle highlight style settings
   $('input[name="highlight-style"]').change(function(){
     var inputVal = $('input[name="highlight-style"]:checked').val();
     $(document.body)
@@ -113,17 +131,16 @@
     updateUserSettings();
   });
 
+
   // Restores default accessibility modal settings
   var accessibilitySettingsResetButton = $('[data-modal-button-reset]');
   accessibilitySettingsResetButton.click(function(event) {
     $(document.body)
       .removeClass(ALL_USER_SETTINGS_CLASSES)
       .addClass(DEFAULT_USER_SETTINGS);
-    updateUserSettings();
-    fontSizeDefault.prop("checked", true);
-    lineHeightDefault.prop("checked", true);
-    contrastDefault.prop("checked", true);
-    noHighlight.prop("checked", true);
+    const userSettings = updateUserSettings();
+    toggleSettingsInputs(userSettings);
+
     return false;
   });
 

--- a/themes/blankslate-child/js/main.js
+++ b/themes/blankslate-child/js/main.js
@@ -1,5 +1,18 @@
 (function($) {
 
+  const DEFAULT_USER_SETTINGS = 'js-font-size-default js-line-height-default js-contrast-default';
+  const ALL_USER_SETTINGS_CLASSES = 'js-font-size-default js-font-size-large js-font-size-extra-large js-line-height-default js-line-height-more js-line-height-max js-contrast-default js-contrast-yellow js-contrast-white js-contrast-blue js-no-highlight js-highlighted';
+  const USER_SETTINGS_KEY = 'userSettings';
+  const BODY_EL = $('body');
+
+  function getUserSettingsFromBody () {
+    return BODY_EL[0].className.split(' ').filter((cls) => cls.match(/js\-/)).join(' ');
+  }
+
+  function updateUserSettings () {
+    localStorage.setItem(USER_SETTINGS_KEY, getUserSettingsFromBody());
+  }
+
   // Toggle transcripts
   var transcriptButtons = $('[data-transcript="button"]');
   var transcriptTitle = $('[data-transcript="title"]');
@@ -56,8 +69,12 @@
   var lineHeightDefault = $('#line-height-default').prop("checked", true);
   var contrastDefault = $('#contrast-default').prop("checked", true);
   var noHighlight = $('#no-highlight').prop("checked", true);
-  $(document.body).addClass('js-font-size-default js-line-height-default js-contrast-default');
-
+  var userSettings = localStorage.getItem(USER_SETTINGS_KEY);
+  if (!userSettings) {
+    localStorage.setItem(USER_SETTINGS_KEY, DEFAULT_USER_SETTINGS);
+    userSettings = DEFAULT_USER_SETTINGS;
+  }
+  BODY_EL.toggleClass(userSettings, true);
 
   // Toggle font size settings
   $('input[name="font-size"]').change(function(){
@@ -65,6 +82,7 @@
     $(document.body)
       .removeClass('js-font-size-default js-font-size-large js-font-size-extra-large')
       .addClass("js-" + inputVal);
+    updateUserSettings();
   });
 
   // Toggle line height settings
@@ -73,6 +91,7 @@
     $(document.body)
       .removeClass('js-line-height-default js-line-height-more js-line-height-max')
       .addClass("js-" + inputVal);
+    updateUserSettings();
   });
 
 
@@ -82,22 +101,25 @@
     $(document.body)
       .removeClass('js-contrast-default js-contrast-yellow js-contrast-white js-contrast-blue')
       .addClass("js-" + inputVal);
+    updateUserSettings();
   });
 
-  // Toggle highlight style settings
+  // Toggle highlight Cstyle settings
   $('input[name="highlight-style"]').change(function(){
     var inputVal = $('input[name="highlight-style"]:checked').val();
     $(document.body)
       .removeClass('js-no-highlight js-highlighted')
       .addClass("js-" + inputVal);
+    updateUserSettings();
   });
 
   // Restores default accessibility modal settings
   var accessibilitySettingsResetButton = $('[data-modal-button-reset]');
   accessibilitySettingsResetButton.click(function(event) {
     $(document.body)
-      .removeClass('js-font-size-default js-font-size-large js-font-size-extra-large js-line-height-default js-line-height-more js-line-height-max js-contrast-default js-contrast-yellow js-contrast-white js-contrast-blue js-no-highlight js-highlighted')
-      .addClass('js-font-size-default js-line-height-default js-contrast-default js-no-highlight');
+      .removeClass(ALL_USER_SETTINGS_CLASSES)
+      .addClass(DEFAULT_USER_SETTINGS);
+    updateUserSettings();
     fontSizeDefault.prop("checked", true);
     lineHeightDefault.prop("checked", true);
     contrastDefault.prop("checked", true);
@@ -105,5 +127,4 @@
     return false;
   });
 
-
-})(jQuery);
+  })(jQuery);


### PR DESCRIPTION
This PR adds the ability to store user settings for the accessibility settings modal into LocalStorage, allowing it to persist between pages and browsing sessions. It also refactors some existing work for the settings logic to accomplish this.