### PR TITLE
Style skiplink

### DIFF
--- a/themes/blankslate-child/entry.php
+++ b/themes/blankslate-child/entry.php
@@ -5,7 +5,7 @@
 
 <div id="post-<?php the_ID(); ?>" class="l-landing">
 
-  <div class="l-landing__hero">
+  <div id="title" class="l-landing__hero">
     <div class="u-embed-responsive">
       <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/<?php echo $video_id; ?>" title="YouTube: <?php the_title(); ?>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
@@ -14,7 +14,7 @@
   <p class="l-landing__topic c-content__topic">
     Film
   </p>
-  <h1 id="title" class="l-landing__heading c-heading__large">
+  <h1 class="l-landing__heading c-heading__large">
     <?php the_title(); ?>
   </h1>
 

--- a/themes/blankslate-child/footer.php
+++ b/themes/blankslate-child/footer.php
@@ -17,7 +17,7 @@
         <p class="c-partnership__byline">
           A strategic partnership with
         </p>
-        <a href="https://disabilityrightsfund.org/">
+        <a class="c-partnership__link" href="https://disabilityrightsfund.org/">
           <img
             alt="Disability Rights Fund."
             class="c-partnership__logo"

--- a/themes/blankslate-child/header.php
+++ b/themes/blankslate-child/header.php
@@ -39,7 +39,11 @@
 
 <?php wp_body_open(); ?>
 
-<a class="skip-link screen-reader-text" href="#primary"><?php esc_html_e( 'Skip to content', 'disabilityjusticeproject' ); ?></a>
+<a
+  class="c-skipnav"
+  href="#title">
+  <?php esc_html_e( 'Skip to main content', 'disabilityjusticeproject' ); ?>
+</a>
 
 <header
   id="masthead"

--- a/themes/blankslate-child/sass/components/_partnership.scss
+++ b/themes/blankslate-child/sass/components/_partnership.scss
@@ -33,6 +33,16 @@
 }
 
 
+.c-partnership__link {
+  &:hover,
+  &:focus {
+    .c-partnership__logo {
+      opacity: 0.65;
+    }
+  }
+}
+
+
 .c-partnership__logo {
   margin-top: var(--size-150);
   width: 4.5rem;

--- a/themes/blankslate-child/sass/components/_skipnav.scss
+++ b/themes/blankslate-child/sass/components/_skipnav.scss
@@ -1,0 +1,34 @@
+.c-skipnav {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+
+  &:focus {
+    clip: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    position: static;
+    width: auto;
+
+    display: block;
+    background-color: var(--color-gold);
+    color: var(--color-black);
+    font-size: var(--font-size-200);
+    padding: var(--size-100) var(--size-550);
+    position: absolute;
+      top: 0;
+      right: 0;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/themes/blankslate-child/sass/layouts/_landing.scss
+++ b/themes/blankslate-child/sass/layouts/_landing.scss
@@ -16,7 +16,7 @@
 
 .l-landing__hero {
   margin-bottom: 2.5rem;
-  grid-column: 1 / 2;
+  grid-column: 1 / 3;
 
   @media (min-width: $breakpoint-700) {
     grid-column: 2 / 12;
@@ -93,6 +93,7 @@
 
 .l-landing__content {
   max-width: 72ch;
+  grid-column: 1 / 2;
 
   @media (min-width: $breakpoint-700) {
     grid-column: 5 / 10;

--- a/themes/blankslate-child/sass/style.scss
+++ b/themes/blankslate-child/sass/style.scss
@@ -95,6 +95,7 @@ Text Domain: blankslate-child
 @import "components/person";
 @import "components/recommended-video";
 @import "components/share";
+@import "components/skipnav";
 @import "components/tease-news";
 @import "components/tease-project";
 @import "components/update-banner";

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -1411,7 +1411,7 @@ img.u-effect-gold-screen:hover {
 
 .l-landing__hero {
 	margin-bottom: 2.5rem;
-	grid-column: 1 / 2;
+	grid-column: 1 / 3;
 }
 
 @media (min-width: 70em) {
@@ -1495,6 +1495,7 @@ img.u-effect-gold-screen:hover {
 
 .l-landing__content {
 	max-width: 72ch;
+	grid-column: 1 / 2;
 }
 
 @media (min-width: 70em) {
@@ -2446,6 +2447,10 @@ a:focus .c-logo #logotype {
 	}
 }
 
+.c-partnership__link:hover .c-partnership__logo, .c-partnership__link:focus .c-partnership__logo {
+	opacity: 0.65;
+}
+
 .c-partnership__logo {
 	margin-top: var(--size-150);
 	width: 4.5rem;
@@ -2678,6 +2683,40 @@ a:focus .c-logo #logotype {
 
 .c-share__whatsapp .c-share__icon {
 	height: var(--size-250);
+}
+
+.c-skipnav {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}
+
+.c-skipnav:focus {
+	clip: auto;
+	height: auto;
+	margin: 0;
+	overflow: visible;
+	position: static;
+	width: auto;
+	display: block;
+	background-color: var(--color-gold);
+	color: var(--color-black);
+	font-size: var(--font-size-200);
+	padding: var(--size-100) var(--size-550);
+	position: absolute;
+	top: 0;
+	right: 0;
+	text-decoration: none;
+}
+
+.c-skipnav:focus:hover {
+	text-decoration: underline;
 }
 
 .c-tease-news {

--- a/themes/blankslate-child/template-news.php
+++ b/themes/blankslate-child/template-news.php
@@ -14,7 +14,7 @@
   <div class="l-landing">
 
     <?php if ( ! empty($hero)) : ?>
-      <div class="l-landing__hero">
+      <div id="title" class="l-landing__hero">
         <figure
           class="c-content__hero"
           role="figure"
@@ -30,7 +30,7 @@
     <p class="l-landing__topic c-content__topic">
       News
     </p>
-    <h1 id="title" class="l-landing__heading c-heading__large">
+    <h1 <?php if ( ! ($hero)) : ?>id="title"<?php endif; ?> class="l-landing__heading c-heading__large">
       <?php the_title(); ?>
     </h1>
 


### PR DESCRIPTION
This PR styles a skiplink and updates page templates so it can link to the start of the main content area. While the visual jump appears to cover a small distance, it allows a keyboard user to easily bypass repeated primary nav info to more quickly access the page content.

https://user-images.githubusercontent.com/634191/127790330-88825f04-0044-48f7-814f-0c7c989c8949.mp4

