### PR TITLE
Add a dedicated News category page

### DIFF
--- a/themes/blankslate-child/category-news.php
+++ b/themes/blankslate-child/category-news.php
@@ -15,7 +15,7 @@
     <?php
       $args = array(
         'category_name' => 'news',
-        'order'         => 'ASC',
+        'order'         => 'DSC',
         'no_found_rows' => true
       );
       $query = new WP_Query($args);

--- a/themes/blankslate-child/category-news.php
+++ b/themes/blankslate-child/category-news.php
@@ -1,0 +1,30 @@
+<?php
+/**
+* The Film Archive Template
+*/
+
+  get_header();
+?>
+
+<main id="content">
+  <div id="news" class="l-tease-news">
+  <h1 class="l-tease-news__title">
+    News <span class="l-tease-news__emphasis">From the Global Frontlines of Disability Justice</span>
+  </h1>
+  <div class="l-tease-news__posts">
+    <?php
+      $args = array(
+        'category_name' => 'news',
+        'order'         => 'ASC',
+        'no_found_rows' => true
+      );
+      $query = new WP_Query($args);
+
+      while($query -> have_posts()) : $query -> the_post(); ?>
+        <?php get_template_part('tease-news'); ?>
+    <?php endwhile; ?>
+    </div>
+  </div>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
This PR adds a dedicated news category page, and lists news posts in chronologically descending order.