### PR TITLE
Remove inset for homepage videos

### DIFF
--- a/themes/blankslate-child/sass/components/_tease-project.scss
+++ b/themes/blankslate-child/sass/components/_tease-project.scss
@@ -18,12 +18,6 @@
     }
   }
 
-  .page-template-template-homepage &:nth-of-type(n+3) .c-tease-project__video {
-    @media (min-width: $breakpoint-500) {
-      @include homepage-inset("margin", "left");
-    }
-  }
-
   .category-film &:last-of-type {
     border-bottom: none;
   }

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -2839,12 +2839,6 @@ a:focus .c-logo #logotype {
 	}
 }
 
-@media (min-width: 50em) {
-	.page-template-template-homepage .c-tease-project:nth-of-type(n+3) .c-tease-project__video {
-		margin-left: var(--size-900);
-	}
-}
-
 .category-film .c-tease-project:last-of-type {
 	border-bottom: none;
 }


### PR DESCRIPTION
This PR removes the left inset for videos other than the first on the homepage. A PR to extend the first video to the left of the viewport will follow post-launch.

<img width="1193" alt="ScreenCapture at Wed Aug 11 20:52:08 EDT 2021" src="https://user-images.githubusercontent.com/634191/129121925-b43ff443-359e-4a35-b7be-6ce039a50a24.png">
