### PR TITLE
Show transcript on video detail

### DIFF
--- a/themes/blankslate-child/entry-content.php
+++ b/themes/blankslate-child/entry-content.php
@@ -1,7 +1,6 @@
 <?php
   $associated_filmmaker = get_field('associated_filmmaker');
   $behind_the_scenes = get_field('behind_the_scenes');
-  $transcript = get_field('transcript');
 ?>
 
   <div class="l-landing__byline">
@@ -9,31 +8,16 @@
       <?php get_template_part('buttons-share');?>
     </aside>
   </div>
-  <div class="l-landing__content">
+  <div class="l-landing__content js-transcript">
     <div class="c-content c-content--project">
       <?php the_content(); ?>
 
       <div class="c-tease-project__tools">
-        <button
-          data-transcript="button"
-          aria-pressed="false"
-          type="button"
-          class="c-tease-project__transcript">
-          Transcript<span class="sr-only"> for <?php the_title(); ?></span>
-        </button>
+        <?php get_template_part('buttons-transcript');?>
       </div>
     </div>
 
-    <div class="c-tease-project__accordion-wrapper">
-      <section
-        aria-hidden="true"
-        aria-label="Transcript for <?php the_title(); ?>"
-        class="c-tease-project__accordion-content u-flow"
-        data-transcript="content"
-        tabindex="0">
-      <?php echo $transcript; ?>
-      </section>
-    </div>
+    <?php get_template_part('transcript');?>
 
     <?php if ( ! empty($behind_the_scenes)) : ?>
       <div class="c-content c-content--behind-the-scenes">

--- a/themes/blankslate-child/js/main.js
+++ b/themes/blankslate-child/js/main.js
@@ -36,7 +36,7 @@
 
   transcriptButtons.click(function(event) {
     var transcriptButton = $(event.target);
-    var transcriptContent = transcriptButton.parents(".c-tease-project").find('[data-transcript="content"]');
+    var transcriptContent = transcriptButton.parents(".js-transcript").find('[data-transcript="content"]');
 
     if ( transcriptButton.attr('aria-pressed') == 'false' ) {
       transcriptButton.attr("aria-pressed", "true");

--- a/themes/blankslate-child/tease-project.php
+++ b/themes/blankslate-child/tease-project.php
@@ -5,7 +5,7 @@
   $video_id = get_field('video_id');
 ?>
 
-<div class="c-tease-project">
+<div class="c-tease-project js-transcript">
   <div class="c-tease-project__video">
     <div class="u-embed-responsive">
       <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/<?php echo $video_id; ?>" title="YouTube: <?php the_title(); ?>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -50,21 +50,6 @@
 
   </div>
 
-  <div class="c-tease-project__accordion-wrapper">
-    <section
-      aria-hidden="true"
-      aria-describedby="transcript-for-<?php echo sanitize_title(get_the_title()) ?>"
-      class="c-tease-project__accordion-content u-flow"
-      data-transcript="content">
-      <h4
-        id="transcript-for-<?php echo sanitize_title(get_the_title()) ?>"
-        data-transcript="title"
-        class="sr-only"
-        tabindex="-1">
-        Transcript for <?php the_title(); ?>
-      </h4>
-      <?php echo $transcript; ?>
-    </section>
-  </div>
+  <?php get_template_part('transcript');?>
 
 </div>

--- a/themes/blankslate-child/transcript.php
+++ b/themes/blankslate-child/transcript.php
@@ -1,0 +1,20 @@
+<?php
+  $transcript = get_field('transcript');
+?>
+
+<div class="c-tease-project__accordion-wrapper">
+  <section
+    aria-hidden="true"
+    aria-describedby="transcript-for-<?php echo sanitize_title(get_the_title()) ?>"
+    class="c-tease-project__accordion-content u-flow"
+    data-transcript="content">
+    <h4
+      id="transcript-for-<?php echo sanitize_title(get_the_title()) ?>"
+      data-transcript="title"
+      class="sr-only"
+      tabindex="-1">
+      Transcript for <?php the_title(); ?>
+    </h4>
+    <?php echo $transcript; ?>
+  </section>
+</div>


### PR DESCRIPTION
This PR fixes the logic for showing a video transcript on a video detail page. A PR for fixing the styling to follow.

<img width="835" alt="ScreenCapture at Wed Aug 11 21:33:53 EDT 2021" src="https://user-images.githubusercontent.com/634191/129124738-dbdd4a96-d237-4159-8c18-b91bf4b32418.png">
