### PR TITLE
Wrap filmmaker bio text around photo

### DIFF
--- a/themes/blankslate-child/sass/components/_creator.scss
+++ b/themes/blankslate-child/sass/components/_creator.scss
@@ -4,7 +4,6 @@
 
 
 .c-creator__info {
-  display: flex;
   margin-top: var(--size-050);
 }
 
@@ -26,14 +25,29 @@
 
 
 .c-creator__photo {
+float: left;
+shape-outside: circle(50%);
+border: var(--size-100) solid var(--color-black);
+
   background-color: var(--color-gold);
-  border-radius: 100%;
+  border-radius: 75%;
   cursor: pointer;
-  height: var(--size-900);
-  width: var(--size-900);
+  height: var(--size-950);
+  position: relative;
+  bottom: var(--size-050);
+  width: var(--size-950);
+
+  .js-contrast-blue & {
+    border-color: var(--color-dusk-tint);
+  }
+
+  .js-contrast-white & {
+    border-color: var(--color-white);
+  }
 
   .js-contrast-yellow & {
     background-color: var(--color-white);
+    border-color: var(--color-gold);
   }
 }
 
@@ -55,7 +69,6 @@
 
 .c-creator__bio {
   font-size: var(--font-size-150);
-  margin-left: var(--size-200);
   max-width: 65ch;
 }
 

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -3477,7 +3477,6 @@ img.u-effect-gold-screen:hover {
 }
 
 .c-creator__info {
-	display: flex;
 	margin-top: var(--size-050);
 }
 
@@ -3496,15 +3495,29 @@ img.u-effect-gold-screen:hover {
 }
 
 .c-creator__photo {
+	float: left;
+	shape-outside: circle(50%);
+	border: var(--size-100) solid var(--color-black);
 	background-color: var(--color-gold);
-	border-radius: 100%;
+	border-radius: 75%;
 	cursor: pointer;
-	height: var(--size-900);
-	width: var(--size-900);
+	height: var(--size-950);
+	position: relative;
+	bottom: var(--size-050);
+	width: var(--size-950);
+}
+
+.js-contrast-blue .c-creator__photo {
+	border-color: var(--color-dusk-tint);
+}
+
+.js-contrast-white .c-creator__photo {
+	border-color: var(--color-white);
 }
 
 .js-contrast-yellow .c-creator__photo {
 	background-color: var(--color-white);
+	border-color: var(--color-gold);
 }
 
 .c-creator__about-this-video {
@@ -3523,7 +3536,6 @@ img.u-effect-gold-screen:hover {
 
 .c-creator__bio {
 	font-size: var(--font-size-150);
-	margin-left: var(--size-200);
 	max-width: 65ch;
 }
 


### PR DESCRIPTION
This PR uses a clip path to wrap the bio text around the photo. Long story short, you can't flex a float and expect it to do things 😓 

<img width="527" alt="ScreenCapture at Thu Aug 12 22:22:44 EDT 2021" src="https://user-images.githubusercontent.com/634191/129296203-c20bb954-96b9-4a2e-8b8a-4bc918f761e4.png">
