### PR TITLE
Style Able Player audio treatment

### DIFF
--- a/themes/blankslate-child/sass/components/_audio-player.scss
+++ b/themes/blankslate-child/sass/components/_audio-player.scss
@@ -1,5 +1,5 @@
 .c-audio-player__wrapper {
   @include able-player-audio();
-
+  margin-top: calc(var(--size-400) * -1);
   margin-bottom: var(--size-600);
 }

--- a/themes/blankslate-child/sass/logic/_mixin.able-player-styling.scss
+++ b/themes/blankslate-child/sass/logic/_mixin.able-player-styling.scss
@@ -30,6 +30,17 @@
     box-shadow: none !important;
   }
 
+  .able,
+  .able-player,
+  .able-controller {
+    background-color: transparent !important;
+  }
+
+  .able-controller {
+    border-bottom: none;
+    outline: var(--border-thin) solid var(--color-gray-dark);
+  }
+
   .able-seekbar-head,
   .able-seekbar-played {
     background-color: var(--color-brick) !important;
@@ -42,5 +53,24 @@
 
   .able-seekbar-loaded {
     background-color: var(--color-gray-dark) !important;
+  }
+
+  [aria-label="Play"] svg,
+  [aria-label="Pause"] svg {
+    fill: var(--color-brick) !important;
+  }
+
+  [role="button"] svg {
+    fill: var(--color-gray-darkest);
+  }
+
+  .able-elapsedTime,
+  .able-duration,
+  .able-status {
+    color: var(--color-gray-darkest) !important;
+  }
+
+  .able-status {
+    font-style: normal !important;
   }
 }

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -3338,11 +3338,23 @@ img.u-effect-gold-screen:hover {
 }
 
 .c-audio-player__wrapper {
+	margin-top: calc(var(--size-400) * -1);
 	margin-bottom: var(--size-600);
 }
 
 .c-audio-player__wrapper .able {
 	box-shadow: none !important;
+}
+
+.c-audio-player__wrapper .able,
+.c-audio-player__wrapper .able-player,
+.c-audio-player__wrapper .able-controller {
+	background-color: transparent !important;
+}
+
+.c-audio-player__wrapper .able-controller {
+	border-bottom: none;
+	outline: var(--border-thin) solid var(--color-gray-dark);
 }
 
 .c-audio-player__wrapper .able-seekbar-head,
@@ -3357,6 +3369,25 @@ img.u-effect-gold-screen:hover {
 
 .c-audio-player__wrapper .able-seekbar-loaded {
 	background-color: var(--color-gray-dark) !important;
+}
+
+.c-audio-player__wrapper [aria-label="Play"] svg,
+.c-audio-player__wrapper [aria-label="Pause"] svg {
+	fill: var(--color-brick) !important;
+}
+
+.c-audio-player__wrapper [role="button"] svg {
+	fill: var(--color-gray-darkest);
+}
+
+.c-audio-player__wrapper .able-elapsedTime,
+.c-audio-player__wrapper .able-duration,
+.c-audio-player__wrapper .able-status {
+	color: var(--color-gray-darkest) !important;
+}
+
+.c-audio-player__wrapper .able-status {
+	font-style: normal !important;
 }
 
 .c-content h1,


### PR DESCRIPTION
This PR styles the Able Player on news posts to better match the comp.

<img width="704" alt="ScreenCapture at Sun Aug 15 21:15:31 EDT 2021" src="https://user-images.githubusercontent.com/634191/129499299-4eb79942-5488-47df-a406-1b683f43bc3c.png">

@danzedek This is about as close as I could get before things started to really break. It should also hold up for the different themes.