### PR TITLE
Add newsletter signup component

### DIFF
--- a/themes/blankslate-child/category-film.php
+++ b/themes/blankslate-child/category-film.php
@@ -30,6 +30,7 @@
     <?php endwhile; ?>
 
   </div>
+  <?php get_template_part('newsletter-signup');?>
 </main>
 
 <?php get_footer(); ?>

--- a/themes/blankslate-child/newsletter-signup.php
+++ b/themes/blankslate-child/newsletter-signup.php
@@ -1,0 +1,12 @@
+<aside id="newsletter-signup" class="l-newsletter-signup">
+  <div class="l-newsletter-signup__wrapper">
+    <form class="c-newsletter-signup">
+      <legend class="sr-only">
+        Newsletter signup
+      </legend>
+      <label class="c-newsletter-signup__label" for="your-email">Stay up to date on the global disability justice movement</label>
+      <input placeholder="* Your email is required" class="c-newsletter-signup__input" id="your-email" name="your-email" autocomplete="email" autocapitalize="off" autocorrect="off" spellcheck="false" type="email">
+      <input class="c-newsletter-signup__submit" type="submit" value="Submit">
+    </form>
+  </div>
+</aside>

--- a/themes/blankslate-child/sass/components/_input.scss
+++ b/themes/blankslate-child/sass/components/_input.scss
@@ -1,0 +1,35 @@
+.c-input__group {
+  align-items: center;
+  display: flex;
+  margin-top: var(--size-250);
+
+  .c-input__label {
+    font-size: var(--font-size-200);
+    width: 6rem;
+  }
+
+  input:not([type="checkbox"]),
+  textarea {
+    flex: 2;
+  }
+}
+
+
+.c-input__group--textarea {
+  align-items: flex-start;
+}
+
+
+.c-input__submit[type="submit"] {
+  @include form-submit();
+}
+
+.c-input__input[type="text"],
+.c-input__textarea {
+  @include form-input();
+}
+
+
+.c-input__textarea {
+  height: calc(var(--size-900) * 2);
+}

--- a/themes/blankslate-child/sass/components/_newsletter-signup.scss
+++ b/themes/blankslate-child/sass/components/_newsletter-signup.scss
@@ -1,0 +1,42 @@
+.c-newsletter-signup {
+  background-color: var(--color-white);
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-200);
+  padding: var(--size-200) var(--size-400);
+
+  @media (min-width: $breakpoint-600) {
+    flex-direction: row;
+  }
+}
+
+
+.c-newsletter-signup__label {
+  color: var(--color-brick);
+  font-weight: var(--type-weight-bold);
+  line-height: var(--line-height-200);
+}
+
+
+.c-newsletter-signup__input[type="email"] {
+  @include form-input();
+
+  width: 100%;
+
+  @media (min-width: $breakpoint-600) {
+    flex-grow: 1;
+  }
+}
+
+
+.c-newsletter-signup__submit[type="submit"] {
+  @include form-submit();
+
+  padding: var(--size-200) var(--size-600);
+  width: 100%;
+
+  @media (min-width: $breakpoint-600) {
+    width: unset;
+  }
+}

--- a/themes/blankslate-child/sass/layouts/_newsletter-signup.scss
+++ b/themes/blankslate-child/sass/layouts/_newsletter-signup.scss
@@ -1,0 +1,21 @@
+.l-newsletter-signup {
+  padding-right: var(--size-200);
+  padding-bottom: var(--size-700);
+  padding-left: var(--size-200);
+
+  .page-template-template-homepage & {
+    background-color: var(--color-gray-lightest);
+  }
+}
+
+.l-newsletter-signup__wrapper {
+  padding-right: var(--size-250);
+  padding-left: var(--size-250);
+
+  @media (min-width: $breakpoint-500) {
+    @include grid-inset("padding", "large");
+
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+}

--- a/themes/blankslate-child/sass/layouts/_tease-news.scss
+++ b/themes/blankslate-child/sass/layouts/_tease-news.scss
@@ -9,7 +9,6 @@
     display: grid;
     grid-template-columns: 1fr;
     padding-top: var(--size-800);
-    padding-bottom: var(--size-950);
   }
 
   @media (min-width: $breakpoint-500) {

--- a/themes/blankslate-child/sass/logic/_mixin.forms.scss
+++ b/themes/blankslate-child/sass/logic/_mixin.forms.scss
@@ -1,0 +1,14 @@
+@mixin form-input() {
+  border: var(--border-thin) solid var(--color-gray-dark);
+  border-radius: 0;
+  padding: var(--size-150);
+}
+
+
+@mixin form-submit() {
+  background-color: var(--color-black);
+  color: var(--color-white);
+  letter-spacing: var(--tracking-open);
+  padding: var(--size-150);
+  text-transform: uppercase;
+}

--- a/themes/blankslate-child/sass/style.scss
+++ b/themes/blankslate-child/sass/style.scss
@@ -29,6 +29,7 @@ Text Domain: blankslate-child
 @import "logic/mixin.able-player-styling";
 @import "logic/mixin.button";
 @import "logic/mixin.column-width";
+@import "logic/mixin.forms";
 @import "logic/mixin.grid";
 @import "logic/mixin.homepage-inset";
 @import "logic/mixin.read-more-link";
@@ -69,6 +70,7 @@ Text Domain: blankslate-child
 @import "layouts/grid";
 @import "layouts/header";
 @import "layouts/landing";
+@import "layouts/newsletter-signup";
 @import "layouts/tease-news";
 
 // Components
@@ -90,8 +92,10 @@ Text Domain: blankslate-child
 @import "components/creator";
 @import "components/headings";
 @import "components/footer";
+@import "components/input";
 @import "components/logo";
 @import "components/nav-primary";
+@import "components/newsletter-signup";
 @import "components/partnership";
 @import "components/person";
 @import "components/recommended-video";

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -2876,6 +2876,30 @@ img.u-effect-gold-screen:hover {
 	}
 }
 
+.l-newsletter-signup {
+	padding-right: var(--size-200);
+	padding-bottom: var(--size-700);
+	padding-left: var(--size-200);
+}
+
+.page-template-template-homepage .l-newsletter-signup {
+	background-color: var(--color-gray-lightest);
+}
+
+.l-newsletter-signup__wrapper {
+	padding-right: var(--size-250);
+	padding-left: var(--size-250);
+}
+
+@media (min-width: 50em) {
+	.l-newsletter-signup__wrapper {
+		padding-right: 7vw;
+		padding-left: 7vw;
+		display: grid;
+		grid-template-columns: 1fr;
+	}
+}
+
 .l-tease-news {
 	background-color: var(--color-gray-lightest);
 	color: var(--color-gray-darkest);
@@ -2889,7 +2913,6 @@ img.u-effect-gold-screen:hover {
 		display: grid;
 		grid-template-columns: 1fr;
 		padding-top: var(--size-800);
-		padding-bottom: var(--size-950);
 	}
 }
 
@@ -3617,6 +3640,45 @@ img.u-effect-gold-screen:hover {
 	}
 }
 
+.c-input__group {
+	align-items: center;
+	display: flex;
+	margin-top: var(--size-250);
+}
+
+.c-input__group .c-input__label {
+	font-size: var(--font-size-200);
+	width: 6rem;
+}
+
+.c-input__group input:not([type="checkbox"]),
+.c-input__group textarea {
+	flex: 2;
+}
+
+.c-input__group--textarea {
+	align-items: flex-start;
+}
+
+.c-input__submit[type="submit"] {
+	background-color: var(--color-black);
+	color: var(--color-white);
+	letter-spacing: var(--tracking-open);
+	padding: var(--size-150);
+	text-transform: uppercase;
+}
+
+.c-input__input[type="text"],
+.c-input__textarea {
+	border: var(--border-thin) solid var(--color-gray-dark);
+	border-radius: 0;
+	padding: var(--size-150);
+}
+
+.c-input__textarea {
+	height: calc(var(--size-900) * 2);
+}
+
 .c-logo {
 	height: auto;
 	width: 12rem;
@@ -3731,6 +3793,56 @@ a:focus .c-logo #logotype {
 
 .c-nav-primary li:nth-of-type(5) a:hover, .c-nav-primary li:nth-of-type(5) a:focus {
 	border-bottom-color: var(--color-white);
+}
+
+.c-newsletter-signup {
+	background-color: var(--color-white);
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	gap: var(--size-200);
+	padding: var(--size-200) var(--size-400);
+}
+
+@media (min-width: 60em) {
+	.c-newsletter-signup {
+		flex-direction: row;
+	}
+}
+
+.c-newsletter-signup__label {
+	color: var(--color-brick);
+	font-weight: var(--type-weight-bold);
+	line-height: var(--line-height-200);
+}
+
+.c-newsletter-signup__input[type="email"] {
+	border: var(--border-thin) solid var(--color-gray-dark);
+	border-radius: 0;
+	padding: var(--size-150);
+	width: 100%;
+}
+
+@media (min-width: 60em) {
+	.c-newsletter-signup__input[type="email"] {
+		flex-grow: 1;
+	}
+}
+
+.c-newsletter-signup__submit[type="submit"] {
+	background-color: var(--color-black);
+	color: var(--color-white);
+	letter-spacing: var(--tracking-open);
+	padding: var(--size-150);
+	text-transform: uppercase;
+	padding: var(--size-200) var(--size-600);
+	width: 100%;
+}
+
+@media (min-width: 60em) {
+	.c-newsletter-signup__submit[type="submit"] {
+		width: unset;
+	}
 }
 
 .c-partnership {


### PR DESCRIPTION
This PR adds a newsletter signup component to the homepage. It has yet to be hooked up to a subscription service, pending issues with the domain's transfer and MX records.

<img width="1469" alt="ScreenCapture at Tue Aug 17 21:49:07 EDT 2021" src="https://user-images.githubusercontent.com/634191/129823952-fd94af61-5dfa-4cce-b821-d4fd21ee8da0.png">

@danzedek A couple of things:

1. We'll need a treatment for error state and messages.
2. Any chance I could move the placeholder content for email being required to a sublabel either below the title or the input itself? I'm [sorry about the self-promotion](https://www.smashingmagazine.com/2018/06/placeholder-attribute/), but this is one of those accessibility/usability things that's a pet peeve.