### PR TITLE
Small things

### DIFF
--- a/themes/blankslate-child/contact-form.php
+++ b/themes/blankslate-child/contact-form.php
@@ -2,7 +2,7 @@
   $contact_prompt = get_field('contact_prompt');
 ?>
 
-<aside class="c-contact-form">
+<aside class="l-contact-form c-contact-form">
   <details class="c-contact-form__disclosure">
     <summary role="button" class="c-contact-form__summary">
       <span class="c-contact-form__title">

--- a/themes/blankslate-child/entry-content.php
+++ b/themes/blankslate-child/entry-content.php
@@ -26,6 +26,7 @@
     src="<?php echo get_the_post_thumbnail($associated_filmmaker, 'large'); ?>
   <div id="filmmaker" class="c-filmmaker__content">
     <h3 class="c-filmmaker__name">
+      <span class="u-color-text-brick">Filmmaker:</span>
       <?php echo esc_html( $associated_filmmaker->post_title ); ?>
     </h3>
     <div class="c-filmmaker__bio">

--- a/themes/blankslate-child/entry-content.php
+++ b/themes/blankslate-child/entry-content.php
@@ -32,18 +32,19 @@
     <div class="c-filmmaker__bio">
       <?php echo esc_html( $associated_filmmaker->post_excerpt ); ?>
     </div>
-
-    <?php if ( ! empty($behind_the_scenes)) : ?>
-      <div class="c-content c-content--behind-the-scenes">
-        <h1 class="c-heading__large">
-          Behind the scenes
-        </h1>
-        <?php echo $behind_the_scenes; ?>
-      </div>
-    <?php endif; ?>
-
-    <?php get_template_part('contact-form');?>
-
   </div>
+
+  <?php if ( ! empty($behind_the_scenes)) : ?>
+    <p class="l-landing__section l-landing__topic c-content__topic">
+        Behind the scenes
+      </p>
+    <div id="behind-the-scenes" class="u-flow c-filmmaker__behind-the-scenes">
+      <?php echo $behind_the_scenes; ?>
+    </div>
+  <?php endif; ?>
+
+  <?php get_template_part('contact-form');?>
+
+</div>
 
 

--- a/themes/blankslate-child/package-lock.json
+++ b/themes/blankslate-child/package-lock.json
@@ -8,9 +8,6 @@
       "name": "disability-justice-project",
       "version": "1.0.0",
       "license": "GNU General Public License",
-      "dependencies": {
-        "aria-modal-dialog": "^3.3.3"
-      },
       "devDependencies": {
         "@wordpress/scripts": "^12.1.0",
         "dir-archiver": "^1.1.1",
@@ -3519,14 +3516,6 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/aria-modal-dialog": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/aria-modal-dialog/-/aria-modal-dialog-3.3.3.tgz",
-      "integrity": "sha512-Za3wTAj+NOQDU73kVnTUoyrqDxim1NMC625RK3EiWLB5DqESlMqmrnhPoLYJGHC13L6un1/xkr68ooxgj9PriA==",
-      "dependencies": {
-        "inert-polyfill": "^0.2.5"
       }
     },
     "node_modules/aria-query": {
@@ -9435,11 +9424,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/inert-polyfill": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/inert-polyfill/-/inert-polyfill-0.2.5.tgz",
-      "integrity": "sha512-on1Nri2CciTI8hc+BaIGCe1pDO3Qzniivt9HALcse/NGvUvu/4t2uh6REwOU5fx/Nsb5c3dCRPJdvinYH0mlkg=="
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",
@@ -24082,14 +24066,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "aria-modal-dialog": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/aria-modal-dialog/-/aria-modal-dialog-3.3.3.tgz",
-      "integrity": "sha512-Za3wTAj+NOQDU73kVnTUoyrqDxim1NMC625RK3EiWLB5DqESlMqmrnhPoLYJGHC13L6un1/xkr68ooxgj9PriA==",
-      "requires": {
-        "inert-polyfill": "^0.2.5"
-      }
-    },
     "aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
@@ -28781,11 +28757,6 @@
       "requires": {
         "repeating": "^2.0.0"
       }
-    },
-    "inert-polyfill": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/inert-polyfill/-/inert-polyfill-0.2.5.tgz",
-      "integrity": "sha512-on1Nri2CciTI8hc+BaIGCe1pDO3Qzniivt9HALcse/NGvUvu/4t2uh6REwOU5fx/Nsb5c3dCRPJdvinYH0mlkg=="
     },
     "infer-owner": {
       "version": "1.0.4",

--- a/themes/blankslate-child/sass/components/_audio-player.scss
+++ b/themes/blankslate-child/sass/components/_audio-player.scss
@@ -3,3 +3,10 @@
   margin-top: calc(var(--size-400) * -1);
   margin-bottom: var(--size-600);
 }
+
+
+.c-audio-player__title {
+  font-size: var(--font-size-250);
+  font-weight: var(--type-weight-bold);
+  margin-top: var(--size-250) !important;
+}

--- a/themes/blankslate-child/sass/components/_contact-form.scss
+++ b/themes/blankslate-child/sass/components/_contact-form.scss
@@ -4,7 +4,7 @@
   }
 
   .post-template-default & {
-    margin-top: var(--size-200);
+    margin-top: var(--size-700);
   }
 }
 

--- a/themes/blankslate-child/sass/components/_content.scss
+++ b/themes/blankslate-child/sass/components/_content.scss
@@ -72,7 +72,6 @@
 
 .c-content__topic {
   color: var(--color-brick);
-  letter-spacing: var(--tracking-open);
   padding-top: var(--size-100);
 
   .js-contrast-blue & {

--- a/themes/blankslate-child/sass/components/_person.scss
+++ b/themes/blankslate-child/sass/components/_person.scss
@@ -41,6 +41,7 @@ $_person-photo-size: 8rem;
 
 
 .c-filmmaker__content,
+.c-filmmaker__behind-the-scenes,
 .c-mentor__content {
   grid-column: 1 / 2;
   margin-top: var(--size-200);
@@ -58,6 +59,11 @@ $_person-photo-size: 8rem;
 
 .c-filmmaker__content {
   margin-top: var(--size-200);
+}
+
+
+.c-filmmaker__behind-the-scenes {
+  margin-top: var(--size-800);
 }
 
 

--- a/themes/blankslate-child/sass/layouts/_contact-form.scss
+++ b/themes/blankslate-child/sass/layouts/_contact-form.scss
@@ -1,0 +1,17 @@
+.l-contact-form {
+  .post-template-template-news & {
+
+  }
+
+  .post-template-default & {
+    grid-column: 1 / 3;
+
+    @media (min-width: $breakpoint-400) {
+      grid-column: 3 / 10;
+    }
+
+    @media (min-width: $breakpoint-700) {
+      grid-column: 5 / 10;
+    }
+  }
+}

--- a/themes/blankslate-child/sass/style.scss
+++ b/themes/blankslate-child/sass/style.scss
@@ -66,6 +66,7 @@ Text Domain: blankslate-child
 // @import "layouts/content-sidebar"; // Uncomment this line for a sidebar on right side of your content.
 // @import "layouts/sidebar-content"; // Uncomment this line for a sidebar on left side of your content.
 @import "layouts/about";
+@import "layouts/contact-form";
 @import "layouts/footer";
 @import "layouts/grid";
 @import "layouts/header";

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -3688,7 +3688,6 @@ img.u-effect-gold-screen:hover {
 
 .c-content__topic {
 	color: var(--color-brick);
-	letter-spacing: var(--tracking-open);
 	padding-top: var(--size-100);
 }
 

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -2540,6 +2540,22 @@ img.u-effect-gold-screen:hover {
 	margin-top: var(--size-900);
 }
 
+.post-template-default .l-contact-form {
+	grid-column: 1 / 3;
+}
+
+@media (min-width: 40em) {
+	.post-template-default .l-contact-form {
+		grid-column: 3 / 10;
+	}
+}
+
+@media (min-width: 70em) {
+	.post-template-default .l-contact-form {
+		grid-column: 5 / 10;
+	}
+}
+
 .l-footer {
 	border-top: var(--border-thin) solid var(--color-gray-light);
 	display: flex;
@@ -3418,12 +3434,18 @@ img.u-effect-gold-screen:hover {
 	font-style: normal !important;
 }
 
+.c-audio-player__title {
+	font-size: var(--font-size-250);
+	font-weight: var(--type-weight-bold);
+	margin-top: var(--size-250) !important;
+}
+
 .post-template-template-news .c-contact-form {
 	margin-top: var(--size-500);
 }
 
 .post-template-default .c-contact-form {
-	margin-top: var(--size-200);
+	margin-top: var(--size-700);
 }
 
 .c-contact-form__disclosure {
@@ -4137,6 +4159,7 @@ a:focus .c-logo #logotype {
 }
 
 .c-filmmaker__content,
+.c-filmmaker__behind-the-scenes,
 .c-mentor__content {
 	grid-column: 1 / 2;
 	margin-top: var(--size-200);
@@ -4144,6 +4167,7 @@ a:focus .c-logo #logotype {
 
 @media (min-width: 40em) {
 	.c-filmmaker__content,
+	.c-filmmaker__behind-the-scenes,
 	.c-mentor__content {
 		grid-column: 3 / 10;
 		margin-top: var(--size-700);
@@ -4152,6 +4176,7 @@ a:focus .c-logo #logotype {
 
 @media (min-width: 70em) {
 	.c-filmmaker__content,
+	.c-filmmaker__behind-the-scenes,
 	.c-mentor__content {
 		grid-column: 5 / 10;
 	}
@@ -4159,6 +4184,10 @@ a:focus .c-logo #logotype {
 
 .c-filmmaker__content {
 	margin-top: var(--size-200);
+}
+
+.c-filmmaker__behind-the-scenes {
+	margin-top: var(--size-800);
 }
 
 .c-mentor__content {

--- a/themes/blankslate-child/template-resources.php
+++ b/themes/blankslate-child/template-resources.php
@@ -13,7 +13,7 @@
   <div class="l-landing__hero"></div>
 
     <p class="l-landing__topic c-content__topic">
-      Tips and tricks
+      Resources for Filmmakers
     </p>
     <h1 id="title" class="l-landing__heading c-heading__large">
       Resources


### PR DESCRIPTION
This PR:

- Renames "Tips and tricks" to "Resources for Filmmakers"
- Adds a filmmaker prefix on a film project page
- Moves "Behind the scenes" to the left at larger screen sizes, if behind the scenes content is present
- Updates the text size of the audio player text size, if present

@danzedek Unfortunately, adding padding to the player breaks its internal layout—this is due to how they structure its content. I'll take another shot at it post-launch, but right now I want to prioritize other tasks.

<img width="1097" alt="ScreenCapture at Tue Aug 24 21:37:20 EDT 2021" src="https://user-images.githubusercontent.com/634191/130712334-3bb0f97f-2cc7-4188-9a38-0b05c0e28908.png">

<img width="1069" alt="ScreenCapture at Tue Aug 24 21:36:55 EDT 2021" src="https://user-images.githubusercontent.com/634191/130712346-a861a009-e38b-40cd-aeb2-4233bd456beb.png">

<img width="1057" alt="ScreenCapture at Tue Aug 24 21:38:38 EDT 2021" src="https://user-images.githubusercontent.com/634191/130712371-56249a58-1a05-4002-9c99-eea95624eb0a.png">
