### PR TITLE
Update Able Player styling

### DIFF
--- a/themes/blankslate-child/sass/logic/_mixin.able-player-styling.scss
+++ b/themes/blankslate-child/sass/logic/_mixin.able-player-styling.scss
@@ -1,8 +1,20 @@
+@mixin _able-player-shadow() {
+  .able {
+    box-shadow: none !important;
+  }
+}
+
+@mixin _able-player-status() {
+  .able-status {
+    font-style: normal !important;
+  }
+}
+
+
 @mixin able-player-video() {
   .able-wrapper {
-    .able {
-      box-shadow: none !important;
-    }
+    @include _able-player-shadow();
+    @include _able-player-status();
 
     .able-media-container {
       overflow: hidden !important;
@@ -22,13 +34,46 @@
         display: none !important;
       }
     }
+
+    .able-status {
+      font-style: normal !important;
+    }
+
+    [aria-label="Preferences"],
+    [aria-label="Show transcript"] {
+      display: none !important;
+    }
+
+    .able-status-bar {
+      min-height: 2.25em !important;
+    }
+
+    .able-captions {
+      font-family: var(--font-primary) !important;
+    }
+
+    .able-seekbar-head {
+      background-color: var(--color-gold) !important;
+    }
+
+    .able-seekbar-played {
+      background-color: var(--color-white) !important;
+    }
+
+    .able-seekbar{
+      background-color: var(--color-black) !important;
+      border: none !important;
+    }
+
+    .able-seekbar-loaded {
+      background-color: var(--color-gray-dark) !important;
+    }
   }
 }
 
 @mixin able-player-audio() {
-  .able {
-    box-shadow: none !important;
-  }
+  @include _able-player-shadow();
+  @include _able-player-status();
 
   .able,
   .able-player,
@@ -39,20 +84,6 @@
   .able-controller {
     border-bottom: none;
     outline: var(--border-thin) solid var(--color-gray-dark);
-  }
-
-  .able-seekbar-head,
-  .able-seekbar-played {
-    background-color: var(--color-brick) !important;
-  }
-
-  .able-seekbar{
-    background-color: var(--color-black) !important;
-    border: none !important;
-  }
-
-  .able-seekbar-loaded {
-    background-color: var(--color-gray-dark) !important;
   }
 
   [aria-label="Play"] svg,
@@ -70,7 +101,20 @@
     color: var(--color-gray-darkest) !important;
   }
 
-  .able-status {
-    font-style: normal !important;
+  .able-seekbar-head {
+    background-color: var(--color-brick) !important;
+  }
+
+  .able-seekbar-played {
+    background-color: var(--color-gray-medium) !important;
+  }
+
+  .able-seekbar{
+    background-color: var(--color-black) !important;
+    border: none !important;
+  }
+
+  .able-seekbar-loaded {
+    background-color: var(--color-gray-darkest) !important;
   }
 }

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -2686,6 +2686,10 @@ img.u-effect-gold-screen:hover {
 	box-shadow: none !important;
 }
 
+.l-landing__hero .able-wrapper .able-status {
+	font-style: normal !important;
+}
+
 .l-landing__hero .able-wrapper .able-media-container {
 	overflow: hidden !important;
 	padding-top: 56.25%  !important;
@@ -2703,6 +2707,40 @@ img.u-effect-gold-screen:hover {
 
 .l-landing__hero .able-wrapper .able-media-container .able-big-play-button {
 	display: none !important;
+}
+
+.l-landing__hero .able-wrapper .able-status {
+	font-style: normal !important;
+}
+
+.l-landing__hero .able-wrapper [aria-label="Preferences"],
+.l-landing__hero .able-wrapper [aria-label="Show transcript"] {
+	display: none !important;
+}
+
+.l-landing__hero .able-wrapper .able-status-bar {
+	min-height: 2.25em !important;
+}
+
+.l-landing__hero .able-wrapper .able-captions {
+	font-family: var(--font-primary) !important;
+}
+
+.l-landing__hero .able-wrapper .able-seekbar-head {
+	background-color: var(--color-gold) !important;
+}
+
+.l-landing__hero .able-wrapper .able-seekbar-played {
+	background-color: var(--color-white) !important;
+}
+
+.l-landing__hero .able-wrapper .able-seekbar {
+	background-color: var(--color-black) !important;
+	border: none !important;
+}
+
+.l-landing__hero .able-wrapper .able-seekbar-loaded {
+	background-color: var(--color-gray-dark) !important;
 }
 
 @media (min-width: 40em) {
@@ -3390,6 +3428,10 @@ img.u-effect-gold-screen:hover {
 	box-shadow: none !important;
 }
 
+.c-audio-player__wrapper .able-status {
+	font-style: normal !important;
+}
+
 .c-audio-player__wrapper .able,
 .c-audio-player__wrapper .able-player,
 .c-audio-player__wrapper .able-controller {
@@ -3399,20 +3441,6 @@ img.u-effect-gold-screen:hover {
 .c-audio-player__wrapper .able-controller {
 	border-bottom: none;
 	outline: var(--border-thin) solid var(--color-gray-dark);
-}
-
-.c-audio-player__wrapper .able-seekbar-head,
-.c-audio-player__wrapper .able-seekbar-played {
-	background-color: var(--color-brick) !important;
-}
-
-.c-audio-player__wrapper .able-seekbar {
-	background-color: var(--color-black) !important;
-	border: none !important;
-}
-
-.c-audio-player__wrapper .able-seekbar-loaded {
-	background-color: var(--color-gray-dark) !important;
 }
 
 .c-audio-player__wrapper [aria-label="Play"] svg,
@@ -3430,8 +3458,21 @@ img.u-effect-gold-screen:hover {
 	color: var(--color-gray-darkest) !important;
 }
 
-.c-audio-player__wrapper .able-status {
-	font-style: normal !important;
+.c-audio-player__wrapper .able-seekbar-head {
+	background-color: var(--color-brick) !important;
+}
+
+.c-audio-player__wrapper .able-seekbar-played {
+	background-color: var(--color-gray-medium) !important;
+}
+
+.c-audio-player__wrapper .able-seekbar {
+	background-color: var(--color-black) !important;
+	border: none !important;
+}
+
+.c-audio-player__wrapper .able-seekbar-loaded {
+	background-color: var(--color-gray-darkest) !important;
 }
 
 .c-audio-player__title {
@@ -4518,6 +4559,10 @@ a:focus .c-logo #logotype {
 	box-shadow: none !important;
 }
 
+.c-tease-project__video .able-wrapper .able-status {
+	font-style: normal !important;
+}
+
 .c-tease-project__video .able-wrapper .able-media-container {
 	overflow: hidden !important;
 	padding-top: 56.25%  !important;
@@ -4535,6 +4580,40 @@ a:focus .c-logo #logotype {
 
 .c-tease-project__video .able-wrapper .able-media-container .able-big-play-button {
 	display: none !important;
+}
+
+.c-tease-project__video .able-wrapper .able-status {
+	font-style: normal !important;
+}
+
+.c-tease-project__video .able-wrapper [aria-label="Preferences"],
+.c-tease-project__video .able-wrapper [aria-label="Show transcript"] {
+	display: none !important;
+}
+
+.c-tease-project__video .able-wrapper .able-status-bar {
+	min-height: 2.25em !important;
+}
+
+.c-tease-project__video .able-wrapper .able-captions {
+	font-family: var(--font-primary) !important;
+}
+
+.c-tease-project__video .able-wrapper .able-seekbar-head {
+	background-color: var(--color-gold) !important;
+}
+
+.c-tease-project__video .able-wrapper .able-seekbar-played {
+	background-color: var(--color-white) !important;
+}
+
+.c-tease-project__video .able-wrapper .able-seekbar {
+	background-color: var(--color-black) !important;
+	border: none !important;
+}
+
+.c-tease-project__video .able-wrapper .able-seekbar-loaded {
+	background-color: var(--color-gray-dark) !important;
 }
 
 @media (min-width: 70em) {


### PR DESCRIPTION
This PR updates the styling for Able Player. It:

- Removes the captions toggle, in favor of existing transcript functionality
- Removes the preference toggle, as the bulk of it dealt with displaying transcripts
- Uses gold for the video playhead and brick for the audio playhead
- Updates the caption font family to use Halyard Display
- Updates the loaded and playing track colors
- Expands the status bar minimum height to expose the player speed