### PR TITLE
Add About page table of contents

### DIFF
--- a/themes/blankslate-child/sass/components/_content.scss
+++ b/themes/blankslate-child/sass/components/_content.scss
@@ -94,3 +94,10 @@
   font-family: var(--font-tertiary);
   margin-bottom: var(--size-500);
 }
+
+
+.c-content__toc {
+  li {
+    margin-top: var(--size-050);
+  }
+}

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -3750,6 +3750,10 @@ img.u-effect-gold-screen:hover {
 	margin-bottom: var(--size-500);
 }
 
+.c-content__toc li {
+	margin-top: var(--size-050);
+}
+
 .c-creator {
 	margin-top: var(--size-300);
 }

--- a/themes/blankslate-child/template-about.php
+++ b/themes/blankslate-child/template-about.php
@@ -13,7 +13,7 @@
 
     <div class="l-landing__hero"></div>
 
-    <p class="l-landing__topic c-content__topic">
+    <p id="faq" class="l-landing__topic c-content__topic">
       FAQ
     </p>
     <h1 id="title" class="l-landing__heading c-heading__large">
@@ -22,11 +22,27 @@
 
     <div class="l-landing__content">
       <div class="c-content">
+        <nav class="c-content__toc" aria-label="Table of contents">
+          <ul>
+            <li><a href="#what-is-the-disability-justice-project">What is the Disability Justice Project?</a></li>
+            <li><a href="#what-is-participatory-media">What is participatory media?</a></li>
+            <li><a href="#what-is-the-disability-justice-project-fellowship">What is the Disability Justice Project Fellowship?</a>
+              <ul>
+                <li><a href="#who-can-apply-to-djp">Who can apply to DJP?</a></li>
+                <li><a href="#what-is-required-of-the-fellows-and-opds">What is required of the fellows and OPDs?</a></li>
+              </ul>
+            </li>
+            <li><a href="#why-the-disability-justice-project-now">Why the Disability Justice Project now?</a></li>
+            <li><a href="#accessibility-statement">Accessibility statement</a></li>
+            <li><a href="#mentors">Mentors</a></li>
+            <li><a href="#staff">Staff</a></li>
+          </ul>
+        </nav>
         <?php the_content(); ?>
       </div>
     </div>
 
-    <p class="l-landing__section l-landing__topic c-content__topic">
+    <p id="mentors" class="l-landing__section l-landing__topic c-content__topic">
       Our team
     </p>
     <h2 class="l-landing__section l-landing__heading help c-heading__large">
@@ -46,7 +62,7 @@
         <?php get_template_part('mentor'); ?>
     <?php endwhile; ?>
 
-    <h2 class="l-landing__section l-landing__heading help c-heading__large">
+    <h2 id="staff" class="l-landing__section l-landing__heading help c-heading__large">
       Staff
     </h2>
 


### PR DESCRIPTION
This PR adds a table of contents to the About page, to allow users to skip to different sections.

<img width="955" alt="ScreenCapture at Tue Aug 24 23:27:43 EDT 2021" src="https://user-images.githubusercontent.com/634191/130721641-d217d78e-9fe9-45d3-89dc-a15866c0c150.png">
