### PR TITLE
Search bar size tweaks and transcript button adjustment

### DIFF
--- a/themes/blankslate-child/buttons-transcript.php
+++ b/themes/blankslate-child/buttons-transcript.php
@@ -3,5 +3,5 @@
   aria-pressed="false"
   type="button"
   class="c-tease-project__transcript">
-  Descriptive Transcript<span class="sr-only"> for <?php the_title(); ?></span>
+  <span class="c-tease-project__descriptive">Descriptive </span>Transcript<span class="sr-only"> for <?php the_title(); ?></span>
 </button>

--- a/themes/blankslate-child/sass/components/_search.scss
+++ b/themes/blankslate-child/sass/components/_search.scss
@@ -58,7 +58,7 @@ $_search-icon-size: var(--size-250);
   position: absolute;
     top: 8rem;
     right: 1rem;
-  width: calc(100vw - 2.75rem);
+  width: calc(100vw - 1.8rem);
 
   @media (min-width: $breakpoint-750) {
     top: var(--size-450);

--- a/themes/blankslate-child/sass/components/_tease-project.scss
+++ b/themes/blankslate-child/sass/components/_tease-project.scss
@@ -149,6 +149,16 @@
 }
 
 
+.c-tease-project__descriptive {
+  display: none;
+
+  @media (min-width: $breakpoint-400) {
+    display: inline;
+  }
+}
+
+
+
 .c-tease-project__accordion-wrapper {
   background-color: var(--color-gray-lightest);
   color: var(--color-black);

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -4452,7 +4452,7 @@ a:focus .c-logo #logotype {
 	position: absolute;
 	top: 8rem;
 	right: 1rem;
-	width: calc(100vw - 2.75rem);
+	width: calc(100vw - 1.8rem);
 }
 
 @media (min-width: 75em) {
@@ -4943,6 +4943,16 @@ a:focus .c-logo #logotype {
 
 .js-contrast-yellow .c-tease-project__transcript:hover, .js-contrast-yellow .c-tease-project__transcript:focus {
 	background-color: var(--color-white);
+}
+
+.c-tease-project__descriptive {
+	display: none;
+}
+
+@media (min-width: 40em) {
+	.c-tease-project__descriptive {
+		display: inline;
+	}
 }
 
 .c-tease-project__accordion-wrapper {


### PR DESCRIPTION
This PR adjusts the search bar to cover the entire primary nav on small viewports. It also removes the word "descriptive" from the "descriptive transcript" button on small viewports.