### PR TITLE
Update 2021 DJP Fellow sort

### DIFF
--- a/themes/blankslate-child/template-filmmakers.php
+++ b/themes/blankslate-child/template-filmmakers.php
@@ -22,7 +22,7 @@
     </h2>
     <?php
       $args = array(
-        'category_name' => '2021',
+        'category_name' => '2021-djp-fellow',
         'orderby' => '$order_by',
         'order'   => 'ASC',
         'no_found_rows' => true,


### PR DESCRIPTION
This PR updates the `category_name` query to show `2021-djp-fellow`.
