### PR TITLE
Play videos inline on mobile

### DIFF
--- a/themes/blankslate-child/entry.php
+++ b/themes/blankslate-child/entry.php
@@ -13,6 +13,7 @@
       data-root-path="/wp-content/themes/blankslate-child/vendor/ableplayer/"
       data-heading-level="2"
       preload="auto"
+      playsinline
       poster="https://img.youtube.com/vi/<?php echo $video_id; ?>/sddefault.jpg">
     </video>
   </div>

--- a/themes/blankslate-child/tease-project.php
+++ b/themes/blankslate-child/tease-project.php
@@ -14,6 +14,7 @@
       data-root-path="/wp-content/themes/blankslate-child/vendor/ableplayer/"
       data-heading-level="3"
       preload="auto"
+      playsinline
       poster="https://img.youtube.com/vi/<?php echo $video_id; ?>/sddefault.jpg">
     </video>
   </div>


### PR DESCRIPTION
This PR adds the `playsinline` attribute to suppress videos playing fullscreen when activated.

@danzedek I'm unsure how supported this will be with the `video` element to YouTube to Able Player embedding strategy, but I figure it's worth a shot.