### PR TITLE
Make wp-block-images responsive

### DIFF
--- a/themes/blankslate-child/sass/components/_content.scss
+++ b/themes/blankslate-child/sass/components/_content.scss
@@ -73,6 +73,16 @@
 }
 
 
+.wp-block-image {
+  margin-top: var(--size-300);
+
+  img {
+    width: 100%;
+    height: auto;
+  }
+}
+
+
 .c-content__hero {
   border-top: none;
   margin-top: var(--size-450);

--- a/themes/blankslate-child/style.css
+++ b/themes/blankslate-child/style.css
@@ -3826,6 +3826,15 @@ img.u-effect-gold-screen:hover {
 	margin-left: var(--size-100);
 }
 
+.wp-block-image {
+	margin-top: var(--size-300);
+}
+
+.wp-block-image img {
+	width: 100%;
+	height: auto;
+}
+
 .c-content__hero {
 	border-top: none;
 	margin-top: var(--size-450);


### PR DESCRIPTION
This PR fixes images with a parent `.wp-block-images` class, to allow them to shrink for smaller viewports.